### PR TITLE
feat(web): PO detail view page (#105)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,6 +16,7 @@ import { CardsRoute } from "@/pages/cards";
 import { LoopsRoute } from "@/pages/loops";
 import { OrderHistoryRoute } from "@/pages/order-history";
 import { ReceivingRoute } from "@/pages/receiving";
+import { PODetailRoute } from "@/pages/orders/po-detail";
 import type { AuthResponse, AuthSession } from "@/types";
 
 function detectGuestMobileImportLink(): boolean {
@@ -131,6 +132,7 @@ function App() {
           <Route path="parts" element={<ErrorBoundary><PartsRoute session={session} onUnauthorized={clearSession} /></ErrorBoundary>} />
           <Route path="queue" element={<ErrorBoundary><QueueRoute session={session} onUnauthorized={clearSession} /></ErrorBoundary>} />
           <Route path="orders" element={<ErrorBoundary><OrderHistoryRoute session={session} onUnauthorized={clearSession} /></ErrorBoundary>} />
+          <Route path="orders/po/:id" element={<ErrorBoundary><PODetailRoute session={session} onUnauthorized={clearSession} /></ErrorBoundary>} />
           <Route path="receiving" element={<ErrorBoundary><ReceivingRoute session={session} onUnauthorized={clearSession} /></ErrorBoundary>} />
           <Route path="scan" element={<ErrorBoundary><ScanRoute session={session} onUnauthorized={clearSession} /></ErrorBoundary>} />
           <Route path="scan/:cardId" element={<ErrorBoundary><ScanRoute session={session} onUnauthorized={clearSession} /></ErrorBoundary>} />

--- a/apps/web/src/components/orders/po-header.tsx
+++ b/apps/web/src/components/orders/po-header.tsx
@@ -1,0 +1,268 @@
+import * as React from "react";
+import type { PurchaseOrder, POStatus } from "@/types";
+import { PO_STATUS_META } from "@/types";
+import { OrderStatusBadge } from "@/components/order-history/order-status-badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Button,
+  Skeleton,
+} from "@/components/ui";
+import {
+  Printer,
+  Pencil,
+  Send,
+  ChevronDown,
+  Loader2,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/* ── Valid status transitions ──────────────────────────────── */
+
+const VALID_TRANSITIONS: Partial<Record<POStatus, POStatus[]>> = {
+  draft: ["pending_approval", "cancelled"],
+  pending_approval: ["approved", "cancelled", "draft"],
+  approved: ["sent", "cancelled"],
+  sent: ["acknowledged", "partially_received", "cancelled"],
+  acknowledged: ["partially_received", "cancelled"],
+  partially_received: ["received", "cancelled"],
+  received: ["closed", "cancelled"],
+};
+
+/* ── Helpers ───────────────────────────────────────────────── */
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatCurrency(
+  amount: number | string | null | undefined,
+  currency = "USD",
+): string {
+  if (amount === null || amount === undefined) return "—";
+  const num = typeof amount === "string" ? parseFloat(amount) : amount;
+  if (!Number.isFinite(num)) return "—";
+  return new Intl.NumberFormat("en-US", { style: "currency", currency }).format(
+    num,
+  );
+}
+
+/* ── Props ─────────────────────────────────────────────────── */
+
+interface POHeaderProps {
+  po: PurchaseOrder;
+  onEdit?: () => void;
+  onPrint?: () => void;
+  onStatusChange: (status: POStatus) => void;
+  statusUpdating: boolean;
+}
+
+/* ── Status actions dropdown ───────────────────────────────── */
+
+function StatusActionsDropdown({
+  po,
+  onStatusChange,
+  statusUpdating,
+}: {
+  po: PurchaseOrder;
+  onStatusChange: (status: POStatus) => void;
+  statusUpdating: boolean;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const nextStatuses = VALID_TRANSITIONS[po.status];
+
+  if (!nextStatuses || nextStatuses.length === 0) return null;
+
+  return (
+    <div className="relative">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(!open)}
+        disabled={statusUpdating}
+        className="text-xs gap-1"
+      >
+        {statusUpdating ? (
+          <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+        ) : null}
+        {statusUpdating ? "Updating…" : "Update Status"}
+        <ChevronDown className="h-3 w-3" />
+      </Button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div className="absolute right-0 top-full mt-1 z-50 min-w-[180px] rounded-md border border-border bg-background shadow-sm py-1">
+            {nextStatuses.map((status) => {
+              const meta = PO_STATUS_META[status];
+              return (
+                <button
+                  key={status}
+                  onClick={() => {
+                    setOpen(false);
+                    onStatusChange(status);
+                  }}
+                  className={cn(
+                    "w-full text-left px-3 py-1.5 text-xs hover:bg-muted transition-colors",
+                    status === "cancelled" && "text-red-600",
+                  )}
+                >
+                  {meta.label}
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/* ── Component ─────────────────────────────────────────────── */
+
+export function POHeader({
+  po,
+  onEdit,
+  onPrint,
+  onStatusChange,
+  statusUpdating,
+}: POHeaderProps) {
+  const canEdit = po.status === "draft" || po.status === "pending_approval";
+
+  return (
+    <Card className="rounded-xl shadow-sm">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <CardTitle className="text-base">{po.poNumber}</CardTitle>
+            <OrderStatusBadge status={po.status} type="purchase" />
+          </div>
+          <div className="flex items-center gap-2">
+            {canEdit && onEdit && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onEdit}
+                className="text-xs"
+              >
+                <Pencil className="mr-1.5 h-3.5 w-3.5" />
+                Edit
+              </Button>
+            )}
+            {po.status === "draft" && (
+              <Button
+                size="sm"
+                onClick={() => onStatusChange("pending_approval")}
+                disabled={statusUpdating}
+                className="text-xs"
+              >
+                <Send className="mr-1.5 h-3.5 w-3.5" />
+                Submit for Approval
+              </Button>
+            )}
+            {onPrint && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onPrint}
+                className="text-xs"
+              >
+                <Printer className="mr-1.5 h-3.5 w-3.5" />
+                Print
+              </Button>
+            )}
+            <StatusActionsDropdown
+              po={po}
+              onStatusChange={onStatusChange}
+              statusUpdating={statusUpdating}
+            />
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-2 text-sm">
+          <div>
+            <span className="text-muted-foreground">Supplier:</span>{" "}
+            <span className="font-semibold">
+              {po.supplierName ?? "—"}
+            </span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Total:</span>{" "}
+            <span className="font-semibold">
+              {formatCurrency(po.totalAmount, po.currency)}
+            </span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Currency:</span>{" "}
+            <span className="font-semibold">{po.currency}</span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Created:</span>{" "}
+            <span className="font-semibold">{formatDate(po.createdAt)}</span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Ordered:</span>{" "}
+            <span className="font-semibold">{formatDate(po.orderedAt)}</span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Expected Delivery:</span>{" "}
+            <span className="font-semibold">
+              {formatDate(po.expectedDeliveryDate)}
+            </span>
+          </div>
+          {po.paymentTerms && (
+            <div>
+              <span className="text-muted-foreground">Payment Terms:</span>{" "}
+              <span className="font-semibold">{po.paymentTerms}</span>
+            </div>
+          )}
+          {po.shippingTerms && (
+            <div>
+              <span className="text-muted-foreground">Shipping Terms:</span>{" "}
+              <span className="font-semibold">{po.shippingTerms}</span>
+            </div>
+          )}
+          {po.sentToEmail && (
+            <div>
+              <span className="text-muted-foreground">Sent To:</span>{" "}
+              <span className="font-semibold">{po.sentToEmail}</span>
+            </div>
+          )}
+        </div>
+        {po.notes && (
+          <div className="mt-3 text-sm">
+            <span className="text-muted-foreground">Notes:</span>{" "}
+            <span>{po.notes}</span>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function POHeaderSkeleton() {
+  return (
+    <Card className="rounded-xl shadow-sm">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-6 w-36" />
+          <Skeleton className="h-8 w-24" />
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-5 w-40" />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/orders/po-line-items.tsx
+++ b/apps/web/src/components/orders/po-line-items.tsx
@@ -1,0 +1,158 @@
+import type { PurchaseOrderLine } from "@/types";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Skeleton,
+} from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+/* ── Helpers ───────────────────────────────────────────────── */
+
+function formatCurrency(
+  amount: number | string | null | undefined,
+  currency = "USD",
+): string {
+  if (amount === null || amount === undefined) return "—";
+  const num = typeof amount === "string" ? parseFloat(amount) : amount;
+  if (!Number.isFinite(num)) return "—";
+  return new Intl.NumberFormat("en-US", { style: "currency", currency }).format(
+    num,
+  );
+}
+
+/* ── Props ─────────────────────────────────────────────────── */
+
+interface POLineItemsProps {
+  lines: PurchaseOrderLine[];
+  currency?: string;
+}
+
+/* ── Component ─────────────────────────────────────────────── */
+
+export function POLineItems({ lines, currency = "USD" }: POLineItemsProps) {
+  if (lines.length === 0) {
+    return (
+      <Card className="rounded-xl shadow-sm">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm">Line Items</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-xs text-muted-foreground py-4 text-center">
+            No line items on this order.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const grandTotal = lines.reduce((sum, line) => {
+    const price = line.unitPrice ?? 0;
+    return sum + price * line.quantityOrdered;
+  }, 0);
+
+  return (
+    <Card className="rounded-xl shadow-sm">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm">
+          Line Items ({lines.length})
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="bg-muted">
+                <th className="px-3 py-2 text-left font-semibold text-muted-foreground">
+                  Part
+                </th>
+                <th className="px-3 py-2 text-right font-semibold text-muted-foreground">
+                  Ordered
+                </th>
+                <th className="px-3 py-2 text-right font-semibold text-muted-foreground">
+                  Received
+                </th>
+                <th className="px-3 py-2 text-right font-semibold text-muted-foreground">
+                  Unit Price
+                </th>
+                <th className="px-3 py-2 text-right font-semibold text-muted-foreground">
+                  Line Total
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {lines.map((line) => {
+                const lineTotal =
+                  line.unitPrice !== null
+                    ? line.unitPrice * line.quantityOrdered
+                    : null;
+
+                return (
+                  <tr key={line.id} className="hover:bg-muted/30">
+                    <td className="px-3 py-2 font-medium">
+                      {line.partName ?? line.description ?? line.partId}
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums">
+                      {line.quantityOrdered}
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums">
+                      <span
+                        className={cn(
+                          line.quantityReceived >= line.quantityOrdered
+                            ? "text-emerald-600"
+                            : line.quantityReceived > 0
+                              ? "text-amber-600"
+                              : "text-muted-foreground",
+                        )}
+                      >
+                        {line.quantityReceived}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums">
+                      {formatCurrency(line.unitPrice, currency)}
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums font-medium">
+                      {formatCurrency(lineTotal, currency)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+            <tfoot>
+              <tr className="bg-muted/50 border-t border-border">
+                <td
+                  colSpan={4}
+                  className="px-3 py-2 text-right font-semibold text-sm"
+                >
+                  Total
+                </td>
+                <td className="px-3 py-2 text-right tabular-nums font-semibold text-sm">
+                  {formatCurrency(grandTotal, currency)}
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function POLineItemsSkeleton() {
+  return (
+    <Card className="rounded-xl shadow-sm">
+      <CardHeader className="pb-2">
+        <Skeleton className="h-5 w-28" />
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="space-y-0">
+          <Skeleton className="h-9 w-full" />
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/orders/po-timeline.tsx
+++ b/apps/web/src/components/orders/po-timeline.tsx
@@ -1,0 +1,282 @@
+import type { PurchaseOrder, POStatus, Receipt } from "@/types";
+import { PO_STATUS_META } from "@/types";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Badge,
+  Skeleton,
+} from "@/components/ui";
+import { CheckCircle2, CircleDot, Circle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/* ── Helpers ───────────────────────────────────────────────── */
+
+function formatDateTime(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/* ── Status ordering ───────────────────────────────────────── */
+
+const STATUS_PROGRESSION: POStatus[] = [
+  "draft",
+  "pending_approval",
+  "approved",
+  "sent",
+  "acknowledged",
+  "partially_received",
+  "received",
+  "closed",
+];
+
+/* ── Props ─────────────────────────────────────────────────── */
+
+interface POTimelineProps {
+  po: PurchaseOrder;
+}
+
+/* ── Component ─────────────────────────────────────────────── */
+
+export function POTimeline({ po }: POTimelineProps) {
+  const currentIdx = STATUS_PROGRESSION.indexOf(po.status);
+  const isCancelled = po.status === "cancelled";
+
+  type TimelineStep = {
+    status: string;
+    label: string;
+    date: string | null;
+    state: "completed" | "active" | "pending";
+  };
+
+  const steps: TimelineStep[] = [];
+
+  steps.push({
+    status: "created",
+    label: "Created",
+    date: po.createdAt,
+    state: "completed",
+  });
+
+  if (isCancelled) {
+    steps.push({
+      status: "cancelled",
+      label: "Cancelled",
+      date: po.updatedAt,
+      state: "active",
+    });
+  } else {
+    for (let i = 0; i < STATUS_PROGRESSION.length; i++) {
+      const status = STATUS_PROGRESSION[i];
+      if (status === "draft") continue;
+
+      const meta = PO_STATUS_META[status];
+      let state: TimelineStep["state"] = "pending";
+
+      if (i <= currentIdx) {
+        state = i === currentIdx ? "active" : "completed";
+      }
+
+      // Only show steps up to 2 beyond current
+      if (i > currentIdx + 2) break;
+
+      steps.push({
+        status,
+        label: meta.label,
+        date: state !== "pending" ? po.updatedAt : null,
+        state,
+      });
+    }
+  }
+
+  return (
+    <Card className="rounded-xl shadow-sm">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm">Timeline</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-0">
+          {steps.map((step, i) => (
+            <div
+              key={step.status + i}
+              className="flex items-start gap-3 pb-3 last:pb-0"
+            >
+              <div className="flex flex-col items-center">
+                {step.state === "completed" ? (
+                  <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" />
+                ) : step.state === "active" ? (
+                  <CircleDot
+                    className={cn(
+                      "h-4 w-4 shrink-0",
+                      step.status === "cancelled"
+                        ? "text-red-500"
+                        : "text-[hsl(var(--link))]",
+                    )}
+                  />
+                ) : (
+                  <Circle className="h-4 w-4 text-muted-foreground/30 shrink-0" />
+                )}
+                {i < steps.length - 1 && (
+                  <div className="w-px h-4 bg-border mt-0.5" />
+                )}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p
+                  className={cn(
+                    "text-xs font-medium leading-4",
+                    step.state === "active" || step.state === "completed"
+                      ? "text-foreground"
+                      : "text-muted-foreground/50",
+                  )}
+                >
+                  {step.label}
+                </p>
+                {step.date && (
+                  <p className="text-[10px] text-muted-foreground">
+                    {formatDateTime(step.date)}
+                  </p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/* ── Receiving section ──────────────────────────────────────── */
+
+interface POReceivingProps {
+  receipts: Receipt[];
+  loading: boolean;
+}
+
+export function POReceiving({ receipts, loading }: POReceivingProps) {
+  if (loading) {
+    return (
+      <Card className="rounded-xl shadow-sm">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm">Receiving History</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (receipts.length === 0) {
+    return (
+      <Card className="rounded-xl shadow-sm">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm">Receiving History</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-xs text-muted-foreground py-4 text-center">
+            No receipts recorded yet.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="rounded-xl shadow-sm">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm">
+          Receiving History ({receipts.length})
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {receipts.map((receipt) => (
+          <div
+            key={receipt.id}
+            className="rounded-lg border border-border px-3 py-2 text-xs space-y-1"
+          >
+            <div className="flex items-center justify-between">
+              <span className="font-medium">
+                Receipt #{receipt.id.slice(0, 8)}
+              </span>
+              <Badge
+                variant={
+                  receipt.status === "completed"
+                    ? "default"
+                    : receipt.status === "rejected"
+                      ? "destructive"
+                      : "secondary"
+                }
+                className="text-[10px]"
+              >
+                {receipt.status}
+              </Badge>
+            </div>
+            <div className="flex items-center gap-3 text-muted-foreground">
+              <span>Received: {formatDateTime(receipt.receivedAt)}</span>
+              {receipt.receivedBy && <span>By: {receipt.receivedBy}</span>}
+            </div>
+            {receipt.notes && (
+              <p className="text-muted-foreground">{receipt.notes}</p>
+            )}
+            {receipt.lines && receipt.lines.length > 0 && (
+              <div className="mt-1 pl-2 border-l-2 border-border space-y-0.5">
+                {receipt.lines.map((line) => (
+                  <div key={line.id} className="flex items-center gap-2">
+                    <span>{line.partName ?? line.partId}</span>
+                    <span className="text-emerald-600">
+                      +{line.quantityAccepted}
+                    </span>
+                    {line.quantityDamaged > 0 && (
+                      <span className="text-amber-600">
+                        dmg: {line.quantityDamaged}
+                      </span>
+                    )}
+                    {line.quantityRejected > 0 && (
+                      <span className="text-red-600">
+                        rej: {line.quantityRejected}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function POTimelineSkeleton() {
+  return (
+    <Card className="rounded-xl shadow-sm">
+      <CardHeader className="pb-2">
+        <Skeleton className="h-5 w-20" />
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex items-start gap-3">
+              <Skeleton className="h-4 w-4 rounded-full" />
+              <div className="space-y-1">
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-2 w-32" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/hooks/use-purchase-order-detail.ts
+++ b/apps/web/src/hooks/use-purchase-order-detail.ts
@@ -1,0 +1,132 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  isUnauthorized,
+  parseApiError,
+  fetchPurchaseOrder,
+  updatePurchaseOrderStatus,
+  fetchReceiptsForOrder,
+} from "@/lib/api-client";
+import type { PurchaseOrder, POStatus, Receipt } from "@/types";
+
+interface UsePurchaseOrderDetailOptions {
+  token: string;
+  poId: string;
+  onUnauthorized: () => void;
+}
+
+export function usePurchaseOrderDetail({
+  token,
+  poId,
+  onUnauthorized,
+}: UsePurchaseOrderDetailOptions) {
+  const [po, setPo] = useState<PurchaseOrder | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [receipts, setReceipts] = useState<Receipt[]>([]);
+  const [receiptsLoading, setReceiptsLoading] = useState(false);
+
+  const [statusUpdating, setStatusUpdating] = useState(false);
+
+  const isMountedRef = useRef(true);
+  const fetchIdRef = useRef(0);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const loadPo = useCallback(async () => {
+    const id = ++fetchIdRef.current;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const raw = await fetchPurchaseOrder(token, poId);
+      if (id !== fetchIdRef.current || !isMountedRef.current) return;
+      // fetchPurchaseOrder returns the raw API response; the PO data may be
+      // nested under a `data` key depending on the API shape.
+      const data = (raw && typeof raw === "object" && "data" in raw)
+        ? (raw as unknown as { data: PurchaseOrder }).data
+        : raw;
+      setPo(data);
+    } catch (err) {
+      if (id !== fetchIdRef.current || !isMountedRef.current) return;
+      if (isUnauthorized(err)) {
+        onUnauthorized();
+        return;
+      }
+      setError(parseApiError(err));
+    } finally {
+      if (id === fetchIdRef.current && isMountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [token, poId, onUnauthorized]);
+
+  const loadReceipts = useCallback(async () => {
+    setReceiptsLoading(true);
+    try {
+      const data = await fetchReceiptsForOrder(token, poId);
+      if (isMountedRef.current) setReceipts(data);
+    } catch {
+      if (isMountedRef.current) setReceipts([]);
+    } finally {
+      if (isMountedRef.current) setReceiptsLoading(false);
+    }
+  }, [token, poId]);
+
+  useEffect(() => {
+    loadPo();
+    loadReceipts();
+  }, [loadPo, loadReceipts]);
+
+  const updateStatus = useCallback(
+    async (status: POStatus, notes?: string, cancelReason?: string): Promise<boolean> => {
+      if (!po) return false;
+      setStatusUpdating(true);
+      try {
+        const raw = await updatePurchaseOrderStatus(token, po.id, {
+          status,
+          notes,
+          cancelReason,
+        } as Parameters<typeof updatePurchaseOrderStatus>[2]);
+        if (!isMountedRef.current) return false;
+        // Unwrap data if nested
+        const updated = (raw && typeof raw === "object" && "data" in raw)
+          ? (raw as unknown as { data: PurchaseOrder }).data
+          : raw;
+        setPo(updated);
+        return true;
+      } catch (err) {
+        if (!isMountedRef.current) return false;
+        if (isUnauthorized(err)) {
+          onUnauthorized();
+          return false;
+        }
+        throw err;
+      } finally {
+        if (isMountedRef.current) setStatusUpdating(false);
+      }
+    },
+    [token, po, onUnauthorized],
+  );
+
+  const refresh = useCallback(() => {
+    loadPo();
+    loadReceipts();
+  }, [loadPo, loadReceipts]);
+
+  return {
+    po,
+    loading,
+    error,
+    receipts,
+    receiptsLoading,
+    statusUpdating,
+    updateStatus,
+    refresh,
+  };
+}

--- a/apps/web/src/pages/orders/po-detail.tsx
+++ b/apps/web/src/pages/orders/po-detail.tsx
@@ -1,0 +1,199 @@
+import * as React from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import type { AuthSession, POStatus } from "@/types";
+import { usePurchaseOrderDetail } from "@/hooks/use-purchase-order-detail";
+import { POHeader, POHeaderSkeleton } from "@/components/orders/po-header";
+import {
+  POLineItems,
+  POLineItemsSkeleton,
+} from "@/components/orders/po-line-items";
+import {
+  POTimeline,
+  POTimelineSkeleton,
+  POReceiving,
+} from "@/components/orders/po-timeline";
+import {
+  Button,
+  Card,
+  CardContent,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from "@/components/ui";
+import { ArrowLeft, AlertCircle, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+import { parseApiError } from "@/lib/api-client";
+
+/* ── Props ─────────────────────────────────────────────────── */
+
+interface Props {
+  session: AuthSession;
+  onUnauthorized: () => void;
+}
+
+/* ── Tab type ──────────────────────────────────────────────── */
+
+type DetailTab = "lines" | "timeline" | "receiving";
+
+/* ── Component ─────────────────────────────────────────────── */
+
+export function PODetailRoute({ session, onUnauthorized }: Props) {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = React.useState<DetailTab>("lines");
+
+  const {
+    po,
+    loading,
+    error,
+    receipts,
+    receiptsLoading,
+    statusUpdating,
+    updateStatus,
+    refresh,
+  } = usePurchaseOrderDetail({
+    token: session.tokens.accessToken,
+    poId: id ?? "",
+    onUnauthorized,
+  });
+
+  const handleBack = React.useCallback(() => {
+    navigate("/orders");
+  }, [navigate]);
+
+  const handleStatusChange = React.useCallback(
+    async (status: POStatus) => {
+      try {
+        const cancelReason =
+          status === "cancelled" ? "Cancelled from PO detail page" : undefined;
+        const ok = await updateStatus(status, undefined, cancelReason);
+        if (ok) {
+          const label =
+            status === "pending_approval"
+              ? "Submitted for Approval"
+              : status.charAt(0).toUpperCase() +
+                status.slice(1).replace(/_/g, " ");
+          toast.success(`Status updated to ${label}`);
+        }
+      } catch (err) {
+        toast.error(parseApiError(err));
+      }
+    },
+    [updateStatus],
+  );
+
+  const handlePrint = React.useCallback(() => {
+    window.print();
+  }, []);
+
+  /* Loading state */
+  if (loading) {
+    return (
+      <div className="space-y-4 p-4">
+        <Button variant="ghost" size="sm" onClick={handleBack}>
+          <ArrowLeft className="mr-1.5 h-4 w-4" /> Back to Orders
+        </Button>
+        <POHeaderSkeleton />
+        <POLineItemsSkeleton />
+        <POTimelineSkeleton />
+      </div>
+    );
+  }
+
+  /* Error state */
+  if (error) {
+    return (
+      <div className="space-y-4 p-4">
+        <Button variant="ghost" size="sm" onClick={handleBack}>
+          <ArrowLeft className="mr-1.5 h-4 w-4" /> Back to Orders
+        </Button>
+        <Card className="rounded-xl">
+          <CardContent className="py-8 text-center">
+            <AlertCircle className="mx-auto mb-3 h-10 w-10 text-red-400" />
+            <p className="text-sm text-red-600 mb-3">{error}</p>
+            <Button variant="outline" size="sm" onClick={refresh}>
+              <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+              Retry
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  /* No PO found */
+  if (!po) {
+    return (
+      <div className="space-y-4 p-4">
+        <Button variant="ghost" size="sm" onClick={handleBack}>
+          <ArrowLeft className="mr-1.5 h-4 w-4" /> Back to Orders
+        </Button>
+        <Card className="rounded-xl">
+          <CardContent className="py-8 text-center text-sm text-muted-foreground">
+            Purchase order not found.
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      {/* Back navigation */}
+      <Button variant="ghost" size="sm" onClick={handleBack}>
+        <ArrowLeft className="mr-1.5 h-4 w-4" /> Back to Orders
+      </Button>
+
+      {/* Header */}
+      <POHeader
+        po={po}
+        onPrint={handlePrint}
+        onStatusChange={handleStatusChange}
+        statusUpdating={statusUpdating}
+      />
+
+      {/* Tabs */}
+      <Tabs>
+        <TabsList>
+          <TabsTrigger
+            active={activeTab === "lines"}
+            onClick={() => setActiveTab("lines")}
+          >
+            Line Items{po.lines ? ` (${po.lines.length})` : ""}
+          </TabsTrigger>
+          <TabsTrigger
+            active={activeTab === "timeline"}
+            onClick={() => setActiveTab("timeline")}
+          >
+            Timeline
+          </TabsTrigger>
+          <TabsTrigger
+            active={activeTab === "receiving"}
+            onClick={() => setActiveTab("receiving")}
+          >
+            Receiving{receipts.length > 0 ? ` (${receipts.length})` : ""}
+          </TabsTrigger>
+        </TabsList>
+
+        {activeTab === "lines" && (
+          <TabsContent>
+            <POLineItems lines={po.lines ?? []} currency={po.currency} />
+          </TabsContent>
+        )}
+
+        {activeTab === "timeline" && (
+          <TabsContent>
+            <POTimeline po={po} />
+          </TabsContent>
+        )}
+
+        {activeTab === "receiving" && (
+          <TabsContent>
+            <POReceiving receipts={receipts} loading={receiptsLoading} />
+          </TabsContent>
+        )}
+      </Tabs>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **New page** at `/orders/po/:id` with dedicated PO detail view
- **POHeader**: PO number, supplier, status badge, dates, totals, and action buttons with status transition dropdown
- **POLineItems**: table with part, qty ordered/received, unit price, line total, grand total footer with color-coded quantities
- **POTimeline**: status progression visualization (completed/active/pending steps) plus receiving history with receipt cards
- **usePurchaseOrderDetail**: dedicated hook with PO fetch, receipt fetch, status update, and runtime API response unwrapping
- Route registered in App.tsx; TypeScript and Vite build pass clean

## Files Changed

| File | Purpose |
|------|---------|
| `apps/web/src/pages/orders/po-detail.tsx` | Main page with tabs (Line Items, Timeline, Receiving) |
| `apps/web/src/components/orders/po-header.tsx` | Header card with status, metadata, actions |
| `apps/web/src/components/orders/po-line-items.tsx` | Line items table with totals |
| `apps/web/src/components/orders/po-timeline.tsx` | Status timeline + receiving history |
| `apps/web/src/hooks/use-purchase-order-detail.ts` | Data fetching hook |
| `apps/web/src/App.tsx` | Route registration |

## Design System Compliance

- Colors: `--primary`, `--link`, `--muted-foreground`, `--border`
- Spacing: Tailwind 4px base (`gap-2`, `gap-3`, `gap-4`)
- Typography: `text-sm` (14px base), `text-xs` (12px), Open Sans weights
- Border radius: `rounded-xl` (cards), `rounded-md` (buttons)
- Shadows: `shadow-sm` on cards
- Reuses existing `OrderStatusBadge` component

## Test plan

- [ ] Navigate to `/orders` and click a PO row to open detail view
- [ ] Verify PO header shows number, supplier, status, dates, totals
- [ ] Switch between Line Items, Timeline, and Receiving tabs
- [ ] Verify line items table shows correct quantities and totals
- [ ] Test status transition dropdown (Submit for Approval, etc.)
- [ ] Verify Print button triggers browser print dialog
- [ ] Test back button navigates to `/orders`
- [ ] Test loading skeleton displays during fetch
- [ ] Test error state shows retry button
- [ ] Test 404 state for invalid PO ID

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)