### PR TITLE
fix(db): add DbOrTransaction type to fix PgTransaction type errors

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,5 +1,7 @@
 import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/postgres-js';
+import type { PgDatabase } from 'drizzle-orm/pg-core';
+import type { PostgresJsQueryResultHKT } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from './schema/index.js';
 
@@ -70,4 +72,15 @@ export function createDbPool(options?: { max?: number; idleTimeout?: number }) {
 }
 
 export type Database = typeof db;
+
+/**
+ * Common base type that accepts both `db` and transaction `tx` arguments.
+ * Use this for helper functions that are called inside `db.transaction()`.
+ *
+ * `Database` (= `typeof db`) includes `{ $client }` which `PgTransaction`
+ * does not carry, so passing `tx` to a `Database`-typed param fails.
+ * `DbOrTransaction` uses the shared `PgDatabase` base that both extend.
+ */
+export type DbOrTransaction = PgDatabase<PostgresJsQueryResultHKT, typeof schema>;
+
 export { schema };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,3 @@
 export { db, withTenantContext, createMigrationClient } from './client.js';
-export type { Database } from './client.js';
+export type { Database, DbOrTransaction } from './client.js';
 export * as schema from './schema/index.js';

--- a/services/orders/src/routes/transfer-orders.routes.ts
+++ b/services/orders/src/routes/transfer-orders.routes.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { eq, and, sql } from 'drizzle-orm';
 import { db, schema } from '@arda/db';
-import type { Database } from '@arda/db';
+import type { DbOrTransaction } from '@arda/db';
 import type { AuthRequest } from '@arda/auth-utils';
 import { getEventBus } from '@arda/events';
 import { config } from '@arda/config';
@@ -42,7 +42,7 @@ function getRequestAuditContext(req: AuthRequest): RequestAuditContext {
 }
 
 async function writeTransferOrderStatusAudit(
-  tx: Database,
+  tx: DbOrTransaction,
   input: {
     tenantId: string;
     transferOrderId: string;
@@ -72,7 +72,7 @@ async function writeTransferOrderStatusAudit(
 }
 
 async function writeTransferOrderCreateAudit(
-  tx: Database,
+  tx: DbOrTransaction,
   input: {
     tenantId: string;
     transferOrderId: string;
@@ -104,7 +104,7 @@ async function writeTransferOrderCreateAudit(
 }
 
 async function writeTransferOrderLinesShippedAudit(
-  tx: Database,
+  tx: DbOrTransaction,
   input: {
     tenantId: string;
     transferOrderId: string;
@@ -149,7 +149,7 @@ async function writeTransferOrderLinesShippedAudit(
 }
 
 async function writeTransferOrderLinesReceivedAudit(
-  tx: Database,
+  tx: DbOrTransaction,
   input: {
     tenantId: string;
     transferOrderId: string;


### PR DESCRIPTION
## Summary
- Exports new `DbOrTransaction` type from `@arda/db` — the shared `PgDatabase` base that both `PostgresJsDatabase` and `PgTransaction` extend
- Changes the 4 audit helper functions in `transfer-orders.routes.ts` from `tx: Database` to `tx: DbOrTransaction`
- Resolves all 6 TS2345 errors that were blocking CI on main

## Root Cause
`Database = typeof db` includes `{ $client: Sql<{}> }` (added by the postgres-js driver). Inside `db.transaction(async (tx) => {...})`, the callback's `tx` is a `PgTransaction` which extends `PgDatabase` but does **not** carry `$client`. The audit functions only use `tx.insert()` — they never need `$client`.

## Files Changed
- `packages/db/src/client.ts` — add `DbOrTransaction` type alias
- `packages/db/src/index.ts` — re-export new type
- `services/orders/src/routes/transfer-orders.routes.ts` — use `DbOrTransaction` in 4 audit functions

## Test Plan
- [x] `npx tsc --noEmit` passes in orders service (0 errors, was 6)
- [x] Full `turbo build` passes (9/9 packages)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)