### PR TITLE
feat(#336): Add notification delivery schema, tenant defaults, and enum extensions

### DIFF
--- a/packages/db/drizzle/0004_ivory_notification_deliveries.sql
+++ b/packages/db/drizzle/0004_ivory_notification_deliveries.sql
@@ -1,0 +1,60 @@
+-- Add new notification types to the enum
+ALTER TYPE "notifications"."notification_type" ADD VALUE 'receiving_completed';
+ALTER TYPE "notifications"."notification_type" ADD VALUE 'production_hold';
+ALTER TYPE "notifications"."notification_type" ADD VALUE 'automation_escalated';
+--> statement-breakpoint
+
+-- Create delivery_status enum
+DO $$ BEGIN
+  CREATE TYPE "notifications"."delivery_status" AS ENUM('pending', 'sent', 'delivered', 'failed', 'bounced');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+
+-- Create tenant_default_preferences table
+CREATE TABLE "notifications"."tenant_default_preferences" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"notification_type" "notifications"."notification_type" NOT NULL,
+	"channel" "notifications"."notification_channel" NOT NULL,
+	"is_enabled" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+
+-- Create notification_deliveries table
+CREATE TABLE "notifications"."notification_deliveries" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"notification_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"channel" "notifications"."notification_channel" NOT NULL,
+	"status" "notifications"."delivery_status" DEFAULT 'pending' NOT NULL,
+	"provider" varchar(50),
+	"provider_message_id" varchar(255),
+	"attempt_count" integer DEFAULT 0 NOT NULL,
+	"last_attempt_at" timestamp with time zone,
+	"last_error" text,
+	"delivered_at" timestamp with time zone,
+	"metadata" jsonb DEFAULT '{}'::jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+
+-- Create indexes for tenant_default_preferences
+CREATE INDEX "tenant_default_prefs_tenant_idx" ON "notifications"."tenant_default_preferences" USING btree ("tenant_id");
+--> statement-breakpoint
+CREATE INDEX "tenant_default_prefs_type_idx" ON "notifications"."tenant_default_preferences" USING btree ("notification_type");
+--> statement-breakpoint
+
+-- Create indexes for notification_deliveries
+CREATE INDEX "notif_deliveries_tenant_idx" ON "notifications"."notification_deliveries" USING btree ("tenant_id");
+--> statement-breakpoint
+CREATE INDEX "notif_deliveries_user_status_idx" ON "notifications"."notification_deliveries" USING btree ("user_id","status");
+--> statement-breakpoint
+CREATE INDEX "notif_deliveries_notification_idx" ON "notifications"."notification_deliveries" USING btree ("notification_id");
+--> statement-breakpoint
+CREATE INDEX "notif_deliveries_status_created_idx" ON "notifications"."notification_deliveries" USING btree ("status","created_at");

--- a/packages/db/src/schema/notifications.ts
+++ b/packages/db/src/schema/notifications.ts
@@ -8,6 +8,7 @@ import {
   jsonb,
   index,
   pgEnum,
+  integer,
 } from 'drizzle-orm/pg-core';
 
 export const notificationsSchema = pgSchema('notifications');
@@ -24,12 +25,23 @@ export const notificationTypeEnum = pgEnum('notification_type', [
   'wo_status_change',
   'transfer_status_change',
   'system_alert',
+  'receiving_completed',
+  'production_hold',
+  'automation_escalated',
 ]);
 
 export const notificationChannelEnum = pgEnum('notification_channel', [
   'in_app',
   'email',
   'webhook',
+]);
+
+export const deliveryStatusEnum = pgEnum('delivery_status', [
+  'pending',
+  'sent',
+  'delivered',
+  'failed',
+  'bounced',
 ]);
 
 // ─── Notifications ───────────────────────────────────────────────────
@@ -72,5 +84,51 @@ export const notificationPreferences = notificationsSchema.table(
   (table) => [
     index('notif_prefs_user_idx').on(table.userId),
     index('notif_prefs_tenant_idx').on(table.tenantId),
+  ]
+);
+
+// ─── Tenant Default Preferences ──────────────────────────────────────
+export const tenantDefaultPreferences = notificationsSchema.table(
+  'tenant_default_preferences',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    tenantId: uuid('tenant_id').notNull(),
+    notificationType: notificationTypeEnum('notification_type').notNull(),
+    channel: notificationChannelEnum('channel').notNull(),
+    isEnabled: boolean('is_enabled').notNull().default(true),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('tenant_default_prefs_tenant_idx').on(table.tenantId),
+    index('tenant_default_prefs_type_idx').on(table.notificationType),
+  ]
+);
+
+// ─── Notification Deliveries ─────────────────────────────────────────
+export const notificationDeliveries = notificationsSchema.table(
+  'notification_deliveries',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    tenantId: uuid('tenant_id').notNull(),
+    notificationId: uuid('notification_id').notNull(),
+    userId: uuid('user_id').notNull(),
+    channel: notificationChannelEnum('channel').notNull(),
+    status: deliveryStatusEnum('status').notNull().default('pending'),
+    provider: varchar('provider', { length: 50 }),
+    providerMessageId: varchar('provider_message_id', { length: 255 }),
+    attemptCount: integer('attempt_count').notNull().default(0),
+    lastAttemptAt: timestamp('last_attempt_at', { withTimezone: true }),
+    lastError: text('last_error'),
+    deliveredAt: timestamp('delivered_at', { withTimezone: true }),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>().default({}),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('notif_deliveries_tenant_idx').on(table.tenantId),
+    index('notif_deliveries_user_status_idx').on(table.userId, table.status),
+    index('notif_deliveries_notification_idx').on(table.notificationId),
+    index('notif_deliveries_status_created_idx').on(table.status, table.createdAt),
   ]
 );

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -93,7 +93,17 @@ export type NotificationType =
   | 'exception_alert'
   | 'wo_status_change'
   | 'transfer_status_change'
-  | 'system_alert';
+  | 'system_alert'
+  | 'receiving_completed'
+  | 'production_hold'
+  | 'automation_escalated';
+
+export type DeliveryStatus =
+  | 'pending'
+  | 'sent'
+  | 'delivered'
+  | 'failed'
+  | 'bounced';
 
 // ─── Audit Summary API ───────────────────────────────────────────────
 export type AuditSummaryGranularity = 'day' | 'week';

--- a/services/notifications/src/routes/preferences.routes.ts
+++ b/services/notifications/src/routes/preferences.routes.ts
@@ -43,6 +43,9 @@ const DEFAULT_PREFERENCES = {
   wo_status_change: { inApp: true, email: false, webhook: false },
   transfer_status_change: { inApp: true, email: false, webhook: false },
   system_alert: { inApp: true, email: true, webhook: false },
+  receiving_completed: { inApp: true, email: true, webhook: false },
+  production_hold: { inApp: true, email: true, webhook: false },
+  automation_escalated: { inApp: true, email: true, webhook: true },
 };
 
 const DEFAULT_CHANNEL_PREFERENCES = { inApp: true, email: true, webhook: false };


### PR DESCRIPTION
## Summary

Implements the core notification data-model foundation for MVP-17, adding:
- New `delivery_status` enum for tracking email/webhook delivery lifecycle
- Extended `notification_type` enum with 3 new event types
- `notification_deliveries` table for delivery audit and retry tracking
- `tenant_default_preferences` table for tenant-scoped default notification settings

## Changes

### Database Schema (`packages/db/src/schema/notifications.ts`)
- Added `deliveryStatusEnum` with values: `pending`, `sent`, `delivered`, `failed`, `bounced`
- Extended `notificationTypeEnum` with: `receiving_completed`, `production_hold`, `automation_escalated`
- Created `tenantDefaultPreferences` table with tenant/type indexes
- Created `notificationDeliveries` table with comprehensive indexes for delivery tracking

### Migration (`packages/db/drizzle/0004_ivory_notification_deliveries.sql`)
- Adds new enum values to `notification_type` via ALTER TYPE
- Creates `delivery_status` enum
- Creates both new tables with proper indexes and defaults
- Migration is backward-compatible (enum additions are safe)

### Shared Types (`packages/shared-types/src/index.ts`)
- Extended `NotificationType` union type with 3 new values
- Added `DeliveryStatus` type export for cross-service use

### Notification Service (`services/notifications/src/routes/preferences.routes.ts`)
- Updated `DEFAULT_PREFERENCES` constant with defaults for new notification types:
  - `receiving_completed`: in-app + email enabled
  - `production_hold`: in-app + email enabled
  - `automation_escalated`: in-app + email + webhook enabled

## Acceptance Criteria

- [x] Drizzle migration adds `delivery_status` enum values: `pending`, `sent`, `delivered`, `failed`, `bounced`
- [x] `notification_type` enum is extended with `receiving_completed`, `production_hold`, and `automation_escalated`
- [x] New tables `notifications.notification_deliveries` and `notifications.tenant_default_preferences` are created with indexes defined in the PRD
- [x] Shared contracts/types compile across services after schema changes
- [x] `DEFAULT_PREFERENCES` includes defaults for the new notification types

## Testing

- All notification service tests pass (`npm test --filter=@arda/notifications-service`)
- Full monorepo build succeeds (`npm run build`)
- TypeScript compilation validates schema and type exports

## Dependencies

- Depends on: None
- Blocks: API, worker, and frontend tickets that consume new enums/tables

## Notes

This ticket is schema/data-layer only. No feature logic changes beyond type/enum plumbing. The new tables provide the foundation for:
- Email delivery pipeline with retry (FR-12, FR-13)
- Tenant-level default preferences (US-08)
- Delivery audit visibility (US-09, US-11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)