### PR TITLE
test: unblock remaining CI failures after logger migration

### DIFF
--- a/services/orders/src/routes/order-create-audit.integration.test.ts
+++ b/services/orders/src/routes/order-create-audit.integration.test.ts
@@ -143,6 +143,7 @@ vi.mock('@arda/events', () => ({
 
 vi.mock('@arda/config', () => ({
   config: { REDIS_URL: 'redis://localhost:6379' },
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
 }));
 
 vi.mock('../services/order-number.service.js', () => ({

--- a/services/orders/src/routes/order-mutation-audit.integration.test.ts
+++ b/services/orders/src/routes/order-mutation-audit.integration.test.ts
@@ -143,6 +143,7 @@ vi.mock('@arda/events', () => ({
 
 vi.mock('@arda/config', () => ({
   config: { REDIS_URL: 'redis://localhost:6379' },
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
 }));
 
 vi.mock('../services/order-number.service.js', () => ({

--- a/services/orders/src/routes/order-queue-risk.integration.test.ts
+++ b/services/orders/src/routes/order-queue-risk.integration.test.ts
@@ -77,6 +77,7 @@ vi.mock('@arda/events', () => ({
 
 vi.mock('@arda/config', () => ({
   config: { REDIS_URL: 'redis://localhost:6379' },
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
 }));
 
 vi.mock('../services/order-number.service.js', () => ({
@@ -241,4 +242,3 @@ describe('queue risk scan endpoint', () => {
     expect(publishMock).not.toHaveBeenCalled();
   });
 });
-

--- a/services/orders/src/routes/order-queue.events.test.ts
+++ b/services/orders/src/routes/order-queue.events.test.ts
@@ -14,6 +14,7 @@ vi.mock('@arda/events', () => ({
 
 vi.mock('@arda/config', () => ({
   config: { REDIS_URL: 'redis://localhost:6379' },
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
 }));
 
 // The route module has many dependencies; for this test we only need

--- a/services/orders/src/routes/order-queue.integration.test.ts
+++ b/services/orders/src/routes/order-queue.integration.test.ts
@@ -158,6 +158,7 @@ vi.mock('@arda/events', () => ({
 
 vi.mock('@arda/config', () => ({
   config: { REDIS_URL: 'redis://localhost:6379' },
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
 }));
 
 vi.mock('../services/order-number.service.js', () => ({

--- a/services/orders/src/routes/purchase-orders.receive.events.integration.test.ts
+++ b/services/orders/src/routes/purchase-orders.receive.events.integration.test.ts
@@ -122,6 +122,7 @@ vi.mock('@arda/events', () => ({
 
 vi.mock('@arda/config', () => ({
   config: { REDIS_URL: 'redis://localhost:6379' },
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
 }));
 
 vi.mock('../services/order-number.service.js', () => ({

--- a/services/orders/src/routes/purchase-orders.send-email.integration.test.ts
+++ b/services/orders/src/routes/purchase-orders.send-email.integration.test.ts
@@ -64,6 +64,7 @@ vi.mock('@arda/config', () => ({
     SMTP_PASS: '',
     EMAIL_FROM: 'noreply@arda.cards',
   },
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
 }));
 
 vi.mock('@arda/events', () => ({

--- a/services/orders/src/routes/transfer-orders.receive.events.integration.test.ts
+++ b/services/orders/src/routes/transfer-orders.receive.events.integration.test.ts
@@ -134,6 +134,7 @@ vi.mock('@arda/events', () => ({
 
 vi.mock('@arda/config', () => ({
   config: { REDIS_URL: 'redis://localhost:6379' },
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
 }));
 
 vi.mock('../services/order-number.service.js', () => ({

--- a/services/orders/src/routes/work-order-mutation-audit.integration.test.ts
+++ b/services/orders/src/routes/work-order-mutation-audit.integration.test.ts
@@ -94,6 +94,7 @@ vi.mock('@arda/events', () => ({
 
 vi.mock('@arda/config', () => ({
   config: { REDIS_URL: 'redis://localhost:6379' },
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
 }));
 
 vi.mock('../services/order-number.service.js', () => ({

--- a/services/orders/src/services/po-dispatch.service.test.ts
+++ b/services/orders/src/services/po-dispatch.service.test.ts
@@ -1,4 +1,16 @@
 import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@arda/config', () => ({
+  config: {
+    SMTP_HOST: 'localhost',
+    SMTP_PORT: 1025,
+    SMTP_USER: '',
+    SMTP_PASS: '',
+    EMAIL_FROM: 'noreply@arda.cards',
+  },
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
 import {
   buildPdfContent,
   ConsoleEmailAdapter,

--- a/services/orders/src/services/procurement-lifecycle.e2e.test.ts
+++ b/services/orders/src/services/procurement-lifecycle.e2e.test.ts
@@ -17,6 +17,19 @@
  */
 
 import { describe, expect, it } from 'vitest';
+
+vi.mock('@arda/config', () => ({
+  config: {
+    SMTP_HOST: 'localhost',
+    SMTP_PORT: 1025,
+    SMTP_USER: '',
+    SMTP_PASS: '',
+    EMAIL_FROM: 'noreply@arda.cards',
+    REDIS_URL: 'redis://localhost:6379',
+  },
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
 import {
   scoreQueueItems,
   consolidateBySupplier,


### PR DESCRIPTION
## Summary
- add `createLogger` to orders route test config mocks that import routes/services now using logger creation
- mock `@arda/config` in PO dispatch/procurement lifecycle tests to avoid env-validation crashes in CI
- align transfer status integration fixture with current transfer route behavior (`transaction`, role, nested `data` payload)
- update api-gateway kanban compat test query mock chain to support `.orderBy(...).execute()` fallback flow

## Verification
- npm run test --workspace @arda/orders-service
- npm run test --workspace @arda/api-gateway
- npx turbo test