### PR TITLE
test: fix orders typecheck in ci

### DIFF
--- a/services/orders/src/services/procurement-lifecycle.e2e.test.ts
+++ b/services/orders/src/services/procurement-lifecycle.e2e.test.ts
@@ -16,7 +16,7 @@
  * dependencies, but they exercise the real service code end-to-end.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('@arda/config', () => ({
   config: {


### PR DESCRIPTION
## Summary
- import `vi` in `procurement-lifecycle.e2e.test.ts` to satisfy TypeScript after adding config mock

## Verification
- npm run typecheck --workspace @arda/orders-service