### PR TITLE
Make deploy workflow resilient to missing Vercel secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,7 +124,8 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Validate Vercel secrets
+      - name: Check Vercel secret availability
+        id: vercel-secrets
         shell: bash
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -138,18 +139,28 @@ jobs:
           [[ -z "${VERCEL_PROJECT_ID}" ]] && missing+=("VERCEL_PROJECT_ID")
 
           if (( ${#missing[@]} > 0 )); then
-            printf 'Missing required secrets: %s\n' "${missing[*]}" >&2
-            exit 1
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Web Deploy"
+              echo ""
+              echo "- status: skipped"
+              echo "- reason: missing Vercel secrets (${missing[*]})"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install dependencies
+        if: steps.vercel-secrets.outputs.configured == 'true'
         run: npm ci
 
       - name: Install Vercel CLI
+        if: steps.vercel-secrets.outputs.configured == 'true'
         run: npm install --global vercel@latest
 
       - name: Resolve deploy target
         id: target
+        if: steps.vercel-secrets.outputs.configured == 'true'
         shell: bash
         run: |
           if [[ "${{ needs.prepare.outputs.is_main }}" == "true" ]]; then
@@ -161,12 +172,14 @@ jobs:
           fi
 
       - name: Pull Vercel environment
+        if: steps.vercel-secrets.outputs.configured == 'true'
         run: vercel pull --yes --environment=${{ steps.target.outputs.environment }} --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Build Vercel output
+        if: steps.vercel-secrets.outputs.configured == 'true'
         run: vercel build ${{ steps.target.outputs.prod_flag }} --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -174,6 +187,7 @@ jobs:
 
       - name: Deploy to Vercel
         id: deploy
+        if: steps.vercel-secrets.outputs.configured == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -182,6 +196,7 @@ jobs:
           echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
 
       - name: Web deploy summary
+        if: steps.vercel-secrets.outputs.configured == 'true'
         run: |
           {
             echo "## Web Deploy"


### PR DESCRIPTION
## Summary
- adjust `Deploy` workflow to gracefully skip Vercel deploy when required secrets are not configured
- keep backend Railway hook trigger active and successful
- preserve explicit summary output for skipped web deploys

## Why
The first live run of `Deploy` triggered correctly from `main` CI, but failed because Vercel secrets are not yet present in repo settings.

## Behavior
- if `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` are present: web deploy runs normally
- if missing: web deploy is marked skipped in the step summary, and workflow does not fail for that reason
