### PR TITLE
feat(printing): full drag-and-drop WYSIWYG card template designer

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -2,4 +2,4 @@
 # Leave unset in local development to use the Vite /api proxy.
 # Example:
 # VITE_API_BASE_URL=https://api-gateway-production-83fa.up.railway.app
-VITE_API_BASE_URL=
+VITE_API_BASE_URL=https://api-gateway-production-83fa.up.railway.app

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,6 +29,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^4.1.0",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.4.6",
     "react": "^18.3.1",

--- a/apps/web/src/components/printing/designer/canvas-surface.tsx
+++ b/apps/web/src/components/printing/designer/canvas-surface.tsx
@@ -1,0 +1,336 @@
+import * as React from 'react';
+import type { CardTemplateDefinition, CardTemplateElement, CardTemplateTextElement } from '@arda/shared-types';
+import type { KanbanPrintData } from '../types';
+import { normalizeImageUrl, resolveBindingToken } from './template-engine';
+
+type InteractionMode = 'drag' | 'resize';
+
+interface CanvasSurfaceProps {
+  definition: CardTemplateDefinition;
+  data: KanbanPrintData;
+  selectedElementId: string | null;
+  onSelectElement: (id: string | null) => void;
+  onDefinitionChange: (definition: CardTemplateDefinition) => void;
+  scale?: number;
+}
+
+const ICON_SVGS: Record<'minimum' | 'location' | 'order' | 'supplier', string> = {
+  minimum:
+    '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#444" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7l9-4 9 4-9 4-9-4z"/><path d="M3 7v10l9 4 9-4V7"/><path d="M12 11v10"/></svg>',
+  location:
+    '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#444" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 1118 0z"/><circle cx="12" cy="10" r="3"/></svg>',
+  order:
+    '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#444" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 3h6v3H9z"/><rect x="6" y="5" width="12" height="16" rx="2"/><path d="M9 11h6"/><path d="M9 15h4"/></svg>',
+  supplier:
+    '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#444" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1 1 0 00.2 1.1l.1.1a1 1 0 010 1.4l-1 1a1 1 0 01-1.4 0l-.1-.1a1 1 0 00-1.1-.2 1 1 0 00-.6.9V20a1 1 0 01-1 1h-1.5a1 1 0 01-1-1v-.1a1 1 0 00-.6-.9 1 1 0 00-1.1.2l-.1.1a1 1 0 01-1.4 0l-1-1a1 1 0 010-1.4l.1-.1a1 1 0 00.2-1.1 1 1 0 00-.9-.6H4a1 1 0 01-1-1v-1.5a1 1 0 011-1h.1a1 1 0 00.9-.6 1 1 0 00-.2-1.1l-.1-.1a1 1 0 010-1.4l1-1a1 1 0 011.4 0l.1.1a1 1 0 001.1.2 1 1 0 00.6-.9V4a1 1 0 011-1h1.5a1 1 0 011 1v.1a1 1 0 00.6.9 1 1 0 001.1-.2l.1-.1a1 1 0 011.4 0l1 1a1 1 0 010 1.4l-.1.1a1 1 0 00-.2 1.1 1 1 0 00.9.6h.1a1 1 0 011 1V13a1 1 0 01-1 1h-.1a1 1 0 00-.9.6z"/></svg>',
+};
+
+function clampElementWithinBounds(definition: CardTemplateDefinition, element: CardTemplateElement): CardTemplateElement {
+  const minX = definition.safeArea.left;
+  const minY = definition.safeArea.top;
+  const maxX = definition.canvas.width - definition.safeArea.right;
+  const maxY = definition.canvas.height - definition.safeArea.bottom;
+
+  let x = element.x;
+  let y = element.y;
+  let w = element.w;
+  let h = element.h;
+
+  if (x < minX) x = minX;
+  if (y < minY) y = minY;
+  if (x + w > maxX) x = Math.max(minX, maxX - w);
+  if (y + h > maxY) y = Math.max(minY, maxY - h);
+
+  w = Math.min(w, maxX - x);
+  h = Math.min(h, maxY - y);
+  w = Math.max(8, w);
+  h = Math.max(8, h);
+
+  return { ...element, x, y, w, h };
+}
+
+function snap(value: number, gridSize: number, enabled: boolean): number {
+  if (!enabled) return value;
+  return Math.round(value / gridSize) * gridSize;
+}
+
+export function CanvasSurface({
+  definition,
+  data,
+  selectedElementId,
+  onSelectElement,
+  onDefinitionChange,
+  scale = 1,
+}: CanvasSurfaceProps) {
+  const [interaction, setInteraction] = React.useState<{
+    id: string;
+    mode: InteractionMode;
+    startClientX: number;
+    startClientY: number;
+    startX: number;
+    startY: number;
+    startW: number;
+    startH: number;
+  } | null>(null);
+  const [inlineEditId, setInlineEditId] = React.useState<string | null>(null);
+
+  const updateElement = React.useCallback((id: string, updater: (element: CardTemplateElement) => CardTemplateElement) => {
+    const nextElements = definition.elements.map((element) => {
+      if (element.id !== id) return element;
+      const updated = updater(element);
+      return clampElementWithinBounds(definition, updated);
+    });
+    onDefinitionChange({ ...definition, elements: nextElements });
+  }, [definition, onDefinitionChange]);
+
+  React.useEffect(() => {
+    if (!interaction) return;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const dx = (event.clientX - interaction.startClientX) / scale;
+      const dy = (event.clientY - interaction.startClientY) / scale;
+
+      updateElement(interaction.id, (element) => {
+        if (interaction.mode === 'drag') {
+          return {
+            ...element,
+            x: snap(interaction.startX + dx, definition.grid.size, definition.grid.enabled),
+            y: snap(interaction.startY + dy, definition.grid.size, definition.grid.enabled),
+          };
+        }
+
+        return {
+          ...element,
+          w: snap(Math.max(8, interaction.startW + dx), definition.grid.size, definition.grid.enabled),
+          h: snap(Math.max(8, interaction.startH + dy), definition.grid.size, definition.grid.enabled),
+        };
+      });
+    };
+
+    const handlePointerUp = () => setInteraction(null);
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp, { once: true });
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [definition.grid.enabled, definition.grid.size, interaction, scale, updateElement]);
+
+  const sortedElements = React.useMemo(
+    () => [...definition.elements].sort((a, b) => a.z - b.z),
+    [definition.elements],
+  );
+
+  const selectedElement = definition.elements.find((element) => element.id === selectedElementId) ?? null;
+
+  const handleKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!selectedElement || selectedElement.locked) return;
+
+    const step = event.shiftKey ? 10 : 1;
+    if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) return;
+
+    event.preventDefault();
+    updateElement(selectedElement.id, (element) => {
+      if (event.key === 'ArrowUp') return { ...element, y: element.y - step };
+      if (event.key === 'ArrowDown') return { ...element, y: element.y + step };
+      if (event.key === 'ArrowLeft') return { ...element, x: element.x - step };
+      return { ...element, x: element.x + step };
+    });
+  }, [selectedElement, updateElement]);
+
+  return (
+    <div className="overflow-auto rounded-md border border-border bg-muted/10 p-3">
+      <div
+        className="mx-auto"
+        style={{
+          width: definition.canvas.width * scale,
+          height: definition.canvas.height * scale,
+        }}
+      >
+        <div
+          tabIndex={0}
+          onKeyDown={handleKeyDown}
+          onClick={() => onSelectElement(null)}
+          style={{
+            position: 'relative',
+            width: definition.canvas.width,
+            height: definition.canvas.height,
+            transform: `scale(${scale})`,
+            transformOrigin: 'top left',
+            background: definition.canvas.background,
+            border: '1px solid #d1d5db',
+            boxSizing: 'border-box',
+            backgroundImage: definition.grid.enabled
+              ? `linear-gradient(to right, rgba(0,0,0,0.06) 1px, transparent 1px), linear-gradient(to bottom, rgba(0,0,0,0.06) 1px, transparent 1px)`
+              : undefined,
+            backgroundSize: definition.grid.enabled ? `${definition.grid.size}px ${definition.grid.size}px` : undefined,
+          }}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              left: definition.safeArea.left,
+              top: definition.safeArea.top,
+              width: definition.canvas.width - definition.safeArea.left - definition.safeArea.right,
+              height: definition.canvas.height - definition.safeArea.top - definition.safeArea.bottom,
+              border: '1px dashed rgba(47,111,204,0.4)',
+              pointerEvents: 'none',
+            }}
+          />
+
+          {sortedElements.map((element) => {
+            const style = element.style ?? {};
+            const isSelected = selectedElementId === element.id;
+            const valueForBoundText = element.type === 'bound_text' ? resolveBindingToken(element.token, data) : '';
+            const valueForFieldRow = element.type === 'field_row_group' ? resolveBindingToken(element.token, data) : '';
+            const imageUrl = element.type === 'image'
+              ? normalizeImageUrl(element.token ? resolveBindingToken(element.token, data) : element.src)
+              : null;
+
+            return (
+              <div
+                key={element.id}
+                role="button"
+                tabIndex={-1}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onSelectElement(element.id);
+                }}
+                onDoubleClick={(event) => {
+                  event.stopPropagation();
+                  if (element.type === 'text') {
+                    setInlineEditId(element.id);
+                  }
+                }}
+                onPointerDown={(event) => {
+                  if (event.button !== 0) return;
+                  event.stopPropagation();
+                  onSelectElement(element.id);
+                  if (element.locked) return;
+                  setInteraction({
+                    id: element.id,
+                    mode: 'drag',
+                    startClientX: event.clientX,
+                    startClientY: event.clientY,
+                    startX: element.x,
+                    startY: element.y,
+                    startW: element.w,
+                    startH: element.h,
+                  });
+                }}
+                style={{
+                  position: 'absolute',
+                  left: element.x,
+                  top: element.y,
+                  width: element.w,
+                  height: element.h,
+                  zIndex: element.z,
+                  border: isSelected ? '1px solid #2F6FCC' : '1px solid transparent',
+                  boxSizing: 'border-box',
+                  cursor: element.locked ? 'default' : 'move',
+                  overflow: 'hidden',
+                  fontFamily: style.fontFamily,
+                  fontSize: style.fontSize,
+                  fontWeight: style.fontWeight,
+                  color: style.color,
+                  textAlign: style.textAlign,
+                  lineHeight: style.lineHeight,
+                  background: style.backgroundColor,
+                  borderRadius: style.borderRadius,
+                  padding: style.padding,
+                  opacity: style.opacity,
+                }}
+              >
+                {element.type === 'bound_text' && (
+                  <div style={{ whiteSpace: 'pre-wrap' }}>{valueForBoundText || element.fallbackText || ''}</div>
+                )}
+
+                {element.type === 'text' && inlineEditId === element.id && (
+                  <textarea
+                    autoFocus
+                    defaultValue={(element as CardTemplateTextElement).text}
+                    className="h-full w-full resize-none border border-primary bg-white p-1 text-xs"
+                    onBlur={(event) => {
+                      updateElement(element.id, (current) => {
+                        if (current.type !== 'text') return current;
+                        return { ...current, text: event.target.value };
+                      });
+                      setInlineEditId(null);
+                    }}
+                  />
+                )}
+
+                {element.type === 'text' && inlineEditId !== element.id && (
+                  <div style={{ whiteSpace: 'pre-wrap' }}>{element.text}</div>
+                )}
+
+                {element.type === 'image' && (
+                  imageUrl
+                    ? <img src={imageUrl} alt="Template element" style={{ width: '100%', height: '100%', objectFit: element.fit ?? 'contain' }} />
+                    : <div className="flex h-full w-full items-center justify-center text-[11px] text-muted-foreground">No image</div>
+                )}
+
+                {element.type === 'qr' && (
+                  <img src={data.qrCodeDataUrl} alt="QR" style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
+                )}
+
+                {element.type === 'icon' && (
+                  <div className="flex h-full w-full items-center justify-center" dangerouslySetInnerHTML={{ __html: ICON_SVGS[element.iconName] }} />
+                )}
+
+                {element.type === 'line' && (
+                  <div
+                    style={{
+                      width: element.type === 'line' && element.orientation === 'horizontal' ? '100%' : (style.strokeWidth ?? 1),
+                      height: element.type === 'line' && element.orientation === 'vertical' ? '100%' : (style.strokeWidth ?? 1),
+                      background: style.strokeColor ?? '#2F6FCC',
+                    }}
+                  />
+                )}
+
+                {element.type === 'rect' && (
+                  <div className="h-full w-full" style={{ background: style.backgroundColor ?? '#2F6FCC' }} />
+                )}
+
+                {element.type === 'notes_box' && (
+                  <div style={{ whiteSpace: 'pre-wrap' }}>{resolveBindingToken('notesText', data)}</div>
+                )}
+
+                {element.type === 'field_row_group' && (
+                  <div className="flex h-full items-start gap-2">
+                    <div className="flex w-8 flex-col items-center" dangerouslySetInnerHTML={{ __html: ICON_SVGS[element.iconName] }} />
+                    <div className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">{valueForFieldRow}</div>
+                  </div>
+                )}
+
+                {isSelected && !element.locked && (
+                  <button
+                    type="button"
+                    aria-label="Resize element"
+                    className="absolute bottom-0 right-0 h-2.5 w-2.5 cursor-se-resize border border-primary bg-white"
+                    onPointerDown={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      setInteraction({
+                        id: element.id,
+                        mode: 'resize',
+                        startClientX: event.clientX,
+                        startClientY: event.clientY,
+                        startX: element.x,
+                        startY: element.y,
+                        startW: element.w,
+                        startH: element.h,
+                      });
+                    }}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/printing/designer/card-template-designer.tsx
+++ b/apps/web/src/components/printing/designer/card-template-designer.tsx
@@ -1,0 +1,515 @@
+import * as React from 'react';
+import { Download, Loader2, Printer } from 'lucide-react';
+import type { CardTemplateDefinition, CardTemplateRecord } from '@arda/shared-types';
+import { toast } from 'sonner';
+import { Button, Input } from '@/components/ui';
+import { CanvasSurface } from './canvas-surface';
+import { ElementToolbox } from './element-toolbox';
+import { InspectorPanel } from './inspector-panel';
+import { TemplateToolbar } from './template-toolbar';
+import { useHistoryState } from './history-store';
+import { createDefaultCardTemplateDefinition } from './template-defaults';
+import type { KanbanPrintData } from '../types';
+import { downloadCardsPdf } from '../print-pipeline';
+import {
+  apiRequest,
+  archiveCardTemplate,
+  cloneCardTemplate,
+  createCardTemplate,
+  fetchCardTemplates,
+  isUnauthorized,
+  parseApiError,
+  setDefaultCardTemplate,
+  updateCardTemplate,
+} from '@/lib/api-client';
+import { printCardsFromIds } from '@/lib/kanban-printing';
+import type { KanbanCard } from '@/types';
+
+const FORMAT = 'order_card_3x5_portrait';
+const LAST_TEMPLATE_STORAGE_KEY = 'card_template_designer:last_template_id';
+
+interface OverrideDraft {
+  title: string;
+  sku: string;
+  minimumText: string;
+  locationText: string;
+  orderText: string;
+  supplierText: string;
+  notesText: string;
+  imageUrl: string;
+}
+
+function buildOverrides(data: KanbanPrintData): OverrideDraft {
+  return {
+    title: data.partDescription || data.partNumber,
+    sku: data.sku || data.partNumber,
+    minimumText: data.minimumText || '',
+    locationText: data.locationText || '',
+    orderText: data.orderText || '',
+    supplierText: data.supplierText || '',
+    notesText: data.notesText || '',
+    imageUrl: data.imageUrl || '',
+  };
+}
+
+function applyOverrides(data: KanbanPrintData, overrides: OverrideDraft): KanbanPrintData {
+  return {
+    ...data,
+    partDescription: overrides.title,
+    sku: overrides.sku,
+    minimumText: overrides.minimumText,
+    locationText: overrides.locationText,
+    orderText: overrides.orderText,
+    supplierText: overrides.supplierText,
+    notesText: overrides.notesText,
+    imageUrl: overrides.imageUrl,
+  };
+}
+
+interface CardTemplateDesignerProps {
+  token: string;
+  partId: string;
+  selectedCard: KanbanCard;
+  basePrintData: KanbanPrintData;
+  onUnauthorized: () => void;
+  onSaved?: () => Promise<void>;
+  onImageUrlSaved?: (url: string) => void;
+}
+
+export function CardTemplateDesigner({
+  token,
+  partId,
+  selectedCard,
+  basePrintData,
+  onUnauthorized,
+  onSaved,
+  onImageUrlSaved,
+}: CardTemplateDesignerProps) {
+  const history = useHistoryState<CardTemplateDefinition>(createDefaultCardTemplateDefinition(), 100);
+
+  const [templates, setTemplates] = React.useState<CardTemplateRecord[]>([]);
+  const [currentDefaultId, setCurrentDefaultId] = React.useState<string | null>(null);
+  const [selectedTemplateId, setSelectedTemplateId] = React.useState<string | null>(null);
+  const [selectedElementId, setSelectedElementId] = React.useState<string | null>(null);
+  const [templateName, setTemplateName] = React.useState('Default 3x5 Portrait');
+  const [isLoadingTemplates, setIsLoadingTemplates] = React.useState(false);
+  const [isSavingTemplate, setIsSavingTemplate] = React.useState(false);
+  const [isPrinting, setIsPrinting] = React.useState(false);
+  const [isDownloadingPdf, setIsDownloadingPdf] = React.useState(false);
+  const [isSavingImageUrl, setIsSavingImageUrl] = React.useState(false);
+  const [overrides, setOverrides] = React.useState<OverrideDraft>(() => buildOverrides(basePrintData));
+
+  const previewData = React.useMemo(() => applyOverrides(basePrintData, overrides), [basePrintData, overrides]);
+
+  const activeTemplate = React.useMemo(
+    () => templates.find((template) => template.id === selectedTemplateId) ?? null,
+    [templates, selectedTemplateId],
+  );
+
+  React.useEffect(() => {
+    setOverrides(buildOverrides(basePrintData));
+  }, [basePrintData]);
+
+  const applySelectedTemplate = React.useCallback((template: CardTemplateRecord | null) => {
+    if (!template) {
+      setSelectedTemplateId(null);
+      setTemplateName('Default 3x5 Portrait');
+      history.reset(createDefaultCardTemplateDefinition());
+      setSelectedElementId(null);
+      return;
+    }
+
+    setSelectedTemplateId(template.id);
+    setTemplateName(template.name);
+    history.reset(template.definition);
+    setSelectedElementId(null);
+  }, [history]);
+
+  const loadTemplates = React.useCallback(async (preferredTemplateId?: string | null) => {
+    setIsLoadingTemplates(true);
+    try {
+      const response = await fetchCardTemplates(token, FORMAT);
+      setTemplates(response.data);
+      setCurrentDefaultId(response.currentDefaultId);
+
+      const storedTemplateId = window.localStorage.getItem(LAST_TEMPLATE_STORAGE_KEY);
+      const pickId = preferredTemplateId ?? storedTemplateId ?? response.currentDefaultId ?? response.data[0]?.id ?? null;
+      const selected = pickId
+        ? response.data.find((template) => template.id === pickId) ?? null
+        : null;
+
+      applySelectedTemplate(selected);
+    } catch (error) {
+      if (isUnauthorized(error)) {
+        onUnauthorized();
+        return;
+      }
+      toast.error(parseApiError(error));
+      applySelectedTemplate(null);
+    } finally {
+      setIsLoadingTemplates(false);
+    }
+  }, [applySelectedTemplate, onUnauthorized, token]);
+
+  React.useEffect(() => {
+    void loadTemplates();
+  }, [loadTemplates]);
+
+  React.useEffect(() => {
+    if (!selectedTemplateId) {
+      window.localStorage.removeItem(LAST_TEMPLATE_STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(LAST_TEMPLATE_STORAGE_KEY, selectedTemplateId);
+  }, [selectedTemplateId]);
+
+  const handleAddElement = React.useCallback((factory: () => CardTemplateDefinition['elements'][number]) => {
+    history.set({
+      ...history.value,
+      elements: [...history.value.elements, factory()],
+    });
+  }, [history]);
+
+  const handleSaveTemplate = React.useCallback(async () => {
+    const name = templateName.trim();
+    if (!name) {
+      toast.error('Template name is required.');
+      return;
+    }
+
+    setIsSavingTemplate(true);
+    try {
+      let savedId: string | null = null;
+      if (selectedTemplateId) {
+        const updated = await updateCardTemplate(token, selectedTemplateId, {
+          name,
+          definition: history.value,
+        });
+        savedId = updated.id;
+      } else {
+        const created = await createCardTemplate(token, {
+          name,
+          format: FORMAT,
+          definition: history.value,
+          makeDefault: templates.length === 0,
+        });
+        savedId = created.id;
+      }
+
+      await loadTemplates(savedId);
+      toast.success('Template saved.');
+    } catch (error) {
+      if (isUnauthorized(error)) {
+        onUnauthorized();
+        return;
+      }
+      toast.error(parseApiError(error));
+    } finally {
+      setIsSavingTemplate(false);
+    }
+  }, [history.value, loadTemplates, onUnauthorized, selectedTemplateId, templateName, templates.length, token]);
+
+  const handleSetDefault = React.useCallback(async () => {
+    if (!selectedTemplateId) {
+      toast.error('Save the template before setting it as default.');
+      return;
+    }
+
+    try {
+      await setDefaultCardTemplate(token, selectedTemplateId);
+      await loadTemplates(selectedTemplateId);
+      toast.success('Default template updated.');
+    } catch (error) {
+      if (isUnauthorized(error)) {
+        onUnauthorized();
+        return;
+      }
+      toast.error(parseApiError(error));
+    }
+  }, [loadTemplates, onUnauthorized, selectedTemplateId, token]);
+
+  const handleCloneTemplate = React.useCallback(async () => {
+    try {
+      if (selectedTemplateId) {
+        const clone = await cloneCardTemplate(token, selectedTemplateId);
+        await loadTemplates(clone.id);
+      } else {
+        const created = await createCardTemplate(token, {
+          name: `${templateName.trim() || 'Untitled'} (Copy)`,
+          format: FORMAT,
+          definition: history.value,
+        });
+        await loadTemplates(created.id);
+      }
+      toast.success('Template duplicated.');
+    } catch (error) {
+      if (isUnauthorized(error)) {
+        onUnauthorized();
+        return;
+      }
+      toast.error(parseApiError(error));
+    }
+  }, [history.value, loadTemplates, onUnauthorized, selectedTemplateId, templateName, token]);
+
+  const handleArchiveTemplate = React.useCallback(async () => {
+    if (!selectedTemplateId) return;
+    try {
+      await archiveCardTemplate(token, selectedTemplateId);
+      await loadTemplates();
+      toast.success('Template archived.');
+    } catch (error) {
+      if (isUnauthorized(error)) {
+        onUnauthorized();
+        return;
+      }
+      toast.error(parseApiError(error));
+    }
+  }, [loadTemplates, onUnauthorized, selectedTemplateId, token]);
+
+  const handlePrint = React.useCallback(async () => {
+    setIsPrinting(true);
+    try {
+      const result = await printCardsFromIds({
+        token,
+        cardIds: [selectedCard.id],
+        format: FORMAT,
+        onUnauthorized,
+        templateId: selectedTemplateId ?? undefined,
+        templateDefinition: history.value,
+        overridesByCardId: {
+          [selectedCard.id]: {
+            partDescription: previewData.partDescription,
+            sku: previewData.sku,
+            minimumText: previewData.minimumText,
+            locationText: previewData.locationText,
+            orderText: previewData.orderText,
+            supplierText: previewData.supplierText,
+            notesText: previewData.notesText,
+            imageUrl: previewData.imageUrl,
+          },
+        },
+      });
+      toast.success(`Print dialog opened for card #${selectedCard.cardNumber}`);
+      if (result.auditError) {
+        toast.warning(`Printed, but audit logging failed: ${result.auditError}`);
+      }
+    } catch (error) {
+      if (isUnauthorized(error)) {
+        onUnauthorized();
+        return;
+      }
+      toast.error(parseApiError(error));
+    } finally {
+      setIsPrinting(false);
+    }
+  }, [history.value, onUnauthorized, previewData, selectedCard.cardNumber, selectedCard.id, selectedTemplateId, token]);
+
+  const handleDownloadPdf = React.useCallback(async () => {
+    setIsDownloadingPdf(true);
+    try {
+      const stamp = new Date().toISOString().slice(0, 10);
+      await downloadCardsPdf([previewData], FORMAT, {
+        templateDefinition: history.value,
+        filename: `card-${previewData.partNumber}-${stamp}.pdf`,
+      });
+      toast.success('PDF downloaded.');
+    } catch (error) {
+      toast.error(parseApiError(error));
+    } finally {
+      setIsDownloadingPdf(false);
+    }
+  }, [history.value, previewData]);
+
+  const handleSaveImageUrl = React.useCallback(async () => {
+    const normalized = overrides.imageUrl.trim();
+    if (!normalized) {
+      toast.error('Enter an image URL before saving.');
+      return;
+    }
+
+    try {
+      const parsed = new URL(normalized);
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        toast.error('Image URL must start with http:// or https://');
+        return;
+      }
+    } catch {
+      toast.error('Image URL must be a valid URL.');
+      return;
+    }
+
+    setIsSavingImageUrl(true);
+    try {
+      await apiRequest(`/api/catalog/parts/${encodeURIComponent(partId)}`, {
+        method: 'PATCH',
+        token,
+        body: { imageUrl: normalized },
+      });
+      onImageUrlSaved?.(normalized);
+      if (onSaved) await onSaved();
+      toast.success('Item image URL updated.');
+    } catch (error) {
+      if (isUnauthorized(error)) {
+        onUnauthorized();
+        return;
+      }
+      toast.error(parseApiError(error));
+    } finally {
+      setIsSavingImageUrl(false);
+    }
+  }, [onImageUrlSaved, onSaved, onUnauthorized, overrides.imageUrl, partId, token]);
+
+  return (
+    <div className="space-y-3">
+      <TemplateToolbar
+        templateName={templateName}
+        onTemplateNameChange={setTemplateName}
+        onNewTemplate={() => {
+          setSelectedTemplateId(null);
+          setTemplateName('Untitled Template');
+          history.reset(createDefaultCardTemplateDefinition());
+          setSelectedElementId(null);
+        }}
+        onSaveTemplate={() => void handleSaveTemplate()}
+        onCloneTemplate={() => void handleCloneTemplate()}
+        onSetDefault={() => void handleSetDefault()}
+        onResetSeed={() => history.set(createDefaultCardTemplateDefinition())}
+        onUndo={history.undo}
+        onRedo={history.redo}
+        canUndo={history.canUndo}
+        canRedo={history.canRedo}
+        isSaving={isSavingTemplate}
+        hasSelectedTemplate={!!selectedTemplateId}
+      />
+
+      <div className="flex flex-wrap items-center gap-2 rounded-md border border-border p-3">
+        <label className="text-xs font-medium text-muted-foreground">Template</label>
+        <select
+          className="h-9 min-w-[260px] rounded-md border border-input bg-background px-3 text-sm"
+          value={selectedTemplateId ?? ''}
+          onChange={(event) => {
+            const id = event.target.value || null;
+            const found = id ? templates.find((template) => template.id === id) ?? null : null;
+            applySelectedTemplate(found);
+          }}
+          disabled={isLoadingTemplates}
+        >
+          <option value="">Unsaved template</option>
+          {templates.map((template) => (
+            <option key={template.id} value={template.id}>
+              {template.name}
+              {template.id === currentDefaultId ? ' (Default)' : ''}
+            </option>
+          ))}
+        </select>
+
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => void loadTemplates(selectedTemplateId)}
+          disabled={isLoadingTemplates}
+        >
+          Refresh
+        </Button>
+
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => void handleArchiveTemplate()}
+          disabled={!selectedTemplateId}
+        >
+          Archive
+        </Button>
+
+        {activeTemplate ? (
+          <span className="text-xs text-muted-foreground">
+            Updated {new Date(activeTemplate.updatedAt).toLocaleString()}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="grid gap-3 xl:grid-cols-[220px_minmax(0,1fr)_340px]">
+        <div className="space-y-3">
+          <ElementToolbox onAddElement={handleAddElement} />
+
+          <div className="space-y-2 rounded-md border border-border p-3">
+            <div className="text-xs font-semibold text-muted-foreground">Print Overrides</div>
+            <BoundField label="Title" value={overrides.title} onChange={(value) => setOverrides((prev) => ({ ...prev, title: value }))} />
+            <BoundField label="SKU" value={overrides.sku} onChange={(value) => setOverrides((prev) => ({ ...prev, sku: value }))} />
+            <BoundField label="Minimum" value={overrides.minimumText} onChange={(value) => setOverrides((prev) => ({ ...prev, minimumText: value }))} />
+            <BoundField label="Location" value={overrides.locationText} onChange={(value) => setOverrides((prev) => ({ ...prev, locationText: value }))} />
+            <BoundField label="Order" value={overrides.orderText} onChange={(value) => setOverrides((prev) => ({ ...prev, orderText: value }))} />
+            <BoundField label="Supplier" value={overrides.supplierText} onChange={(value) => setOverrides((prev) => ({ ...prev, supplierText: value }))} />
+            <label className="block space-y-1 text-xs">
+              <span className="text-[11px] text-muted-foreground">Notes</span>
+              <textarea
+                value={overrides.notesText}
+                onChange={(event) => setOverrides((prev) => ({ ...prev, notesText: event.target.value }))}
+                className="min-h-[72px] w-full rounded-md border border-input bg-background px-2 py-1 text-sm"
+              />
+            </label>
+            <BoundField label="Image URL" value={overrides.imageUrl} onChange={(value) => setOverrides((prev) => ({ ...prev, imageUrl: value }))} />
+            <div className="flex justify-end">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => void handleSaveImageUrl()}
+                disabled={isSavingImageUrl}
+              >
+                {isSavingImageUrl ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+                Save image URL
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <CanvasSurface
+          definition={history.value}
+          data={previewData}
+          selectedElementId={selectedElementId}
+          onSelectElement={setSelectedElementId}
+          onDefinitionChange={history.set}
+          scale={1}
+        />
+
+        <div className="space-y-3">
+          <InspectorPanel
+            definition={history.value}
+            selectedElementId={selectedElementId}
+            onDefinitionChange={history.set}
+          />
+
+          <div className="space-y-2 rounded-md border border-border p-3">
+            <Button type="button" className="w-full" onClick={() => void handlePrint()} disabled={isPrinting}>
+              {isPrinting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Printer className="h-3.5 w-3.5" />}
+              Print 3x5 Portrait
+            </Button>
+
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              onClick={() => void handleDownloadPdf()}
+              disabled={isDownloadingPdf}
+            >
+              {isDownloadingPdf ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Download className="h-3.5 w-3.5" />}
+              Download PDF
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BoundField(props: { label: string; value: string; onChange: (value: string) => void }) {
+  return (
+    <label className="block space-y-1 text-xs">
+      <span className="text-[11px] text-muted-foreground">{props.label}</span>
+      <Input value={props.value} onChange={(event) => props.onChange(event.target.value)} />
+    </label>
+  );
+}

--- a/apps/web/src/components/printing/designer/element-toolbox.tsx
+++ b/apps/web/src/components/printing/designer/element-toolbox.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { Button } from '@/components/ui';
+import type { CardTemplateElement } from '@arda/shared-types';
+
+interface ElementToolboxProps {
+  onAddElement: (factory: () => CardTemplateElement) => void;
+}
+
+const TOOL_DEFS: Array<{ label: string; factory: () => CardTemplateElement }> = [
+  {
+    label: 'Text',
+    factory: () => ({ id: `el-text-${crypto.randomUUID()}`, type: 'text', text: 'New text', x: 24, y: 24, w: 140, h: 30, z: 50 }),
+  },
+  {
+    label: 'Bound Text',
+    factory: () => ({ id: `el-bound-${crypto.randomUUID()}`, type: 'bound_text', token: 'title', fallbackText: 'Bound text', x: 24, y: 60, w: 160, h: 30, z: 50 }),
+  },
+  {
+    label: 'Image',
+    factory: () => ({ id: `el-image-${crypto.randomUUID()}`, type: 'image', token: 'imageUrl', fit: 'contain', x: 24, y: 96, w: 120, h: 80, z: 50 }),
+  },
+  {
+    label: 'QR',
+    factory: () => ({ id: `el-qr-${crypto.randomUUID()}`, type: 'qr', x: 24, y: 182, w: 60, h: 60, z: 50 }),
+  },
+  {
+    label: 'Icon',
+    factory: () => ({ id: `el-icon-${crypto.randomUUID()}`, type: 'icon', iconName: 'minimum', x: 24, y: 248, w: 24, h: 24, z: 50 }),
+  },
+  {
+    label: 'Line',
+    factory: () => ({ id: `el-line-${crypto.randomUUID()}`, type: 'line', orientation: 'horizontal', x: 24, y: 278, w: 120, h: 1, z: 50 }),
+  },
+  {
+    label: 'Rectangle',
+    factory: () => ({ id: `el-rect-${crypto.randomUUID()}`, type: 'rect', x: 24, y: 286, w: 120, h: 24, z: 50, style: { backgroundColor: '#2F6FCC' } }),
+  },
+  {
+    label: 'Notes Box',
+    factory: () => ({ id: `el-notes-${crypto.randomUUID()}`, type: 'notes_box', token: 'notesText', x: 24, y: 316, w: 180, h: 36, z: 50 }),
+  },
+  {
+    label: 'Field Row',
+    factory: () => ({ id: `el-row-${crypto.randomUUID()}`, type: 'field_row_group', iconName: 'minimum', label: 'Minimum', token: 'minimumText', x: 24, y: 358, w: 220, h: 32, z: 50 }),
+  },
+];
+
+export function ElementToolbox({ onAddElement }: ElementToolboxProps) {
+  return (
+    <div className="space-y-2 rounded-md border border-border p-3">
+      <div className="text-xs font-semibold text-muted-foreground">Add Elements</div>
+      <div className="grid grid-cols-2 gap-2">
+        {TOOL_DEFS.map((tool) => (
+          <Button
+            key={tool.label}
+            size="sm"
+            variant="outline"
+            className="justify-start"
+            onClick={() => onAddElement(tool.factory)}
+          >
+            {tool.label}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/printing/designer/history-store.ts
+++ b/apps/web/src/components/printing/designer/history-store.ts
@@ -1,0 +1,65 @@
+import * as React from 'react';
+
+interface HistoryState<T> {
+  past: T[];
+  present: T;
+  future: T[];
+}
+
+export function useHistoryState<T>(initialState: T, limit = 100) {
+  const [state, setState] = React.useState<HistoryState<T>>({
+    past: [],
+    present: initialState,
+    future: [],
+  });
+
+  const set = React.useCallback((next: T) => {
+    setState((prev) => {
+      const past = [...prev.past, prev.present];
+      if (past.length > limit) past.shift();
+      return {
+        past,
+        present: next,
+        future: [],
+      };
+    });
+  }, [limit]);
+
+  const undo = React.useCallback(() => {
+    setState((prev) => {
+      if (prev.past.length === 0) return prev;
+      const previous = prev.past[prev.past.length - 1];
+      return {
+        past: prev.past.slice(0, -1),
+        present: previous,
+        future: [prev.present, ...prev.future],
+      };
+    });
+  }, []);
+
+  const redo = React.useCallback(() => {
+    setState((prev) => {
+      if (prev.future.length === 0) return prev;
+      const next = prev.future[0];
+      return {
+        past: [...prev.past, prev.present],
+        present: next,
+        future: prev.future.slice(1),
+      };
+    });
+  }, []);
+
+  const reset = React.useCallback((next: T) => {
+    setState({ past: [], present: next, future: [] });
+  }, []);
+
+  return {
+    value: state.present,
+    canUndo: state.past.length > 0,
+    canRedo: state.future.length > 0,
+    set,
+    undo,
+    redo,
+    reset,
+  };
+}

--- a/apps/web/src/components/printing/designer/inspector-panel.tsx
+++ b/apps/web/src/components/printing/designer/inspector-panel.tsx
@@ -1,0 +1,189 @@
+import * as React from 'react';
+import { Button, Input } from '@/components/ui';
+import type { CardTemplateBindingToken, CardTemplateDefinition, CardTemplateElement } from '@arda/shared-types';
+
+const TOKENS: CardTemplateBindingToken[] = [
+  'title',
+  'sku',
+  'minimumText',
+  'locationText',
+  'orderText',
+  'supplierText',
+  'notesText',
+  'imageUrl',
+  'qrCodeDataUrl',
+];
+
+interface InspectorPanelProps {
+  definition: CardTemplateDefinition;
+  selectedElementId: string | null;
+  onDefinitionChange: (definition: CardTemplateDefinition) => void;
+}
+
+export function InspectorPanel({ definition, selectedElementId, onDefinitionChange }: InspectorPanelProps) {
+  const selectedElement = React.useMemo(
+    () => definition.elements.find((element) => element.id === selectedElementId) ?? null,
+    [definition.elements, selectedElementId],
+  );
+
+  const updateSelected = React.useCallback((updater: (element: CardTemplateElement) => CardTemplateElement) => {
+    if (!selectedElement) return;
+    const next = definition.elements.map((element) => (element.id === selectedElement.id ? updater(element) : element));
+    onDefinitionChange({ ...definition, elements: next });
+  }, [definition, onDefinitionChange, selectedElement]);
+
+  const removeSelected = React.useCallback(() => {
+    if (!selectedElement) return;
+    if (selectedElement.key && definition.requiredElementKeys.includes(selectedElement.key)) return;
+    onDefinitionChange({
+      ...definition,
+      elements: definition.elements.filter((element) => element.id !== selectedElement.id),
+    });
+  }, [definition, onDefinitionChange, selectedElement]);
+
+  if (!selectedElement) {
+    return (
+      <div className="rounded-md border border-border p-3 text-xs text-muted-foreground">
+        Select an element to edit properties.
+      </div>
+    );
+  }
+
+  const required = !!selectedElement.key && definition.requiredElementKeys.includes(selectedElement.key);
+
+  return (
+    <div className="space-y-3 rounded-md border border-border p-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-xs font-semibold">Inspector</div>
+          <div className="text-[11px] text-muted-foreground">{selectedElement.type}</div>
+        </div>
+        <Button size="sm" variant="outline" onClick={removeSelected} disabled={required}>Delete</Button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 text-xs">
+        <LabelValue label="X">
+          <Input type="number" value={selectedElement.x} onChange={(e) => updateSelected((el) => ({ ...el, x: Number(e.target.value) || 0 }))} />
+        </LabelValue>
+        <LabelValue label="Y">
+          <Input type="number" value={selectedElement.y} onChange={(e) => updateSelected((el) => ({ ...el, y: Number(e.target.value) || 0 }))} />
+        </LabelValue>
+        <LabelValue label="W">
+          <Input type="number" value={selectedElement.w} onChange={(e) => updateSelected((el) => ({ ...el, w: Math.max(1, Number(e.target.value) || 1) }))} />
+        </LabelValue>
+        <LabelValue label="H">
+          <Input type="number" value={selectedElement.h} onChange={(e) => updateSelected((el) => ({ ...el, h: Math.max(1, Number(e.target.value) || 1) }))} />
+        </LabelValue>
+        <LabelValue label="Z">
+          <Input type="number" value={selectedElement.z} onChange={(e) => updateSelected((el) => ({ ...el, z: Math.max(0, Number(e.target.value) || 0) }))} />
+        </LabelValue>
+        <LabelValue label="Locked">
+          <select
+            value={selectedElement.locked ? 'yes' : 'no'}
+            onChange={(e) => updateSelected((el) => ({ ...el, locked: e.target.value === 'yes' }))}
+            className="h-9 rounded-md border border-input bg-background px-2"
+          >
+            <option value="no">No</option>
+            <option value="yes">Yes</option>
+          </select>
+        </LabelValue>
+      </div>
+
+      {(selectedElement.type === 'bound_text' || selectedElement.type === 'image' || selectedElement.type === 'notes_box') && (
+        <LabelValue label="Binding Token">
+          <select
+            value={selectedElement.type === 'bound_text' ? selectedElement.token : selectedElement.type === 'image' ? (selectedElement.token ?? '') : (selectedElement.token ?? 'notesText')}
+            onChange={(e) => {
+              const token = e.target.value as CardTemplateBindingToken;
+              updateSelected((el) => {
+                if (el.type === 'bound_text') return { ...el, token };
+                if (el.type === 'image') return { ...el, token: token === 'imageUrl' ? 'imageUrl' : undefined };
+                if (el.type === 'notes_box') return { ...el, token: token === 'notesText' ? 'notesText' : undefined };
+                return el;
+              });
+            }}
+            className="h-9 rounded-md border border-input bg-background px-2"
+          >
+            {TOKENS.map((token) => (
+              <option key={token} value={token}>{token}</option>
+            ))}
+          </select>
+        </LabelValue>
+      )}
+
+      {selectedElement.type === 'field_row_group' && (
+        <>
+          <LabelValue label="Label">
+            <Input value={selectedElement.label} onChange={(e) => updateSelected((el) => el.type === 'field_row_group' ? { ...el, label: e.target.value } : el)} />
+          </LabelValue>
+          <LabelValue label="Token">
+            <select
+              value={selectedElement.token}
+              onChange={(e) => updateSelected((el) => el.type === 'field_row_group' ? { ...el, token: e.target.value as typeof selectedElement.token } : el)}
+              className="h-9 rounded-md border border-input bg-background px-2"
+            >
+              {['minimumText', 'locationText', 'orderText', 'supplierText'].map((token) => (
+                <option key={token} value={token}>{token}</option>
+              ))}
+            </select>
+          </LabelValue>
+        </>
+      )}
+
+      {selectedElement.type === 'text' && (
+        <LabelValue label="Text">
+          <textarea
+            value={selectedElement.text}
+            onChange={(e) => updateSelected((el) => (el.type === 'text' ? { ...el, text: e.target.value } : el))}
+            className="min-h-20 w-full rounded-md border border-input bg-background px-2 py-1 text-sm"
+          />
+        </LabelValue>
+      )}
+
+      <div className="grid grid-cols-2 gap-2">
+        <LabelValue label="Font size">
+          <Input
+            type="number"
+            value={selectedElement.style?.fontSize ?? ''}
+            onChange={(e) => updateSelected((el) => ({ ...el, style: { ...el.style, fontSize: Number(e.target.value) || undefined } }))}
+          />
+        </LabelValue>
+        <LabelValue label="Weight">
+          <Input
+            type="number"
+            value={selectedElement.style?.fontWeight ?? ''}
+            onChange={(e) => updateSelected((el) => ({ ...el, style: { ...el.style, fontWeight: Number(e.target.value) || undefined } }))}
+          />
+        </LabelValue>
+        <LabelValue label="Text color">
+          <Input
+            type="color"
+            value={selectedElement.style?.color ?? '#111111'}
+            onChange={(e) => updateSelected((el) => ({ ...el, style: { ...el.style, color: e.target.value } }))}
+          />
+        </LabelValue>
+        <LabelValue label="Background">
+          <Input
+            type="color"
+            value={selectedElement.style?.backgroundColor ?? '#ffffff'}
+            onChange={(e) => updateSelected((el) => ({ ...el, style: { ...el.style, backgroundColor: e.target.value } }))}
+          />
+        </LabelValue>
+      </div>
+
+      <div className="flex gap-2">
+        <Button size="sm" variant="outline" onClick={() => updateSelected((el) => ({ ...el, z: el.z + 1 }))}>Bring forward</Button>
+        <Button size="sm" variant="outline" onClick={() => updateSelected((el) => ({ ...el, z: Math.max(0, el.z - 1) }))}>Send backward</Button>
+      </div>
+    </div>
+  );
+}
+
+function LabelValue(props: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1">
+      <span className="text-[11px] text-muted-foreground">{props.label}</span>
+      {props.children}
+    </label>
+  );
+}

--- a/apps/web/src/components/printing/designer/template-defaults.ts
+++ b/apps/web/src/components/printing/designer/template-defaults.ts
@@ -1,0 +1,53 @@
+import type { CardTemplateDefinition } from '@arda/shared-types';
+
+export const CARD_TEMPLATE_REQUIRED_KEYS = [
+  'title',
+  'sku',
+  'qr',
+  'minimum',
+  'location',
+  'order',
+  'supplier',
+  'image',
+  'notes',
+  'top_line',
+  'bottom_bar',
+] as const;
+
+export function createDefaultCardTemplateDefinition(): CardTemplateDefinition {
+  return {
+    version: 1,
+    canvas: {
+      width: 288,
+      height: 480,
+      background: '#eeeeee',
+    },
+    grid: {
+      enabled: true,
+      size: 8,
+      snapThreshold: 4,
+    },
+    safeArea: {
+      top: 13,
+      right: 13,
+      bottom: 13,
+      left: 13,
+    },
+    requiredElementKeys: [...CARD_TEMPLATE_REQUIRED_KEYS],
+    elements: [
+      { id: 'el-title', key: 'title', type: 'bound_text', token: 'title', fallbackText: 'Untitled item', x: 13, y: 13, w: 190, h: 62, z: 10, style: { fontSize: 20, fontWeight: 700, lineHeight: 1.1, color: '#111111' } },
+      { id: 'el-sku', key: 'sku', type: 'bound_text', token: 'sku', x: 13, y: 78, w: 190, h: 20, z: 10, style: { fontSize: 13, color: '#595959' } },
+      { id: 'el-qr', key: 'qr', type: 'qr', x: 213, y: 13, w: 62, h: 62, z: 11 },
+      { id: 'el-top-line', key: 'top_line', type: 'line', orientation: 'horizontal', x: 13, y: 98, w: 262, h: 1, z: 9, style: { strokeColor: '#2F6FCC', strokeWidth: 1 } },
+      { id: 'el-minimum', key: 'minimum', type: 'field_row_group', iconName: 'minimum', label: 'Minimum', token: 'minimumText', x: 13, y: 109, w: 262, h: 33, z: 10, style: { fontSize: 16 } },
+      { id: 'el-location', key: 'location', type: 'field_row_group', iconName: 'location', label: 'Location', token: 'locationText', x: 13, y: 142, w: 262, h: 33, z: 10, style: { fontSize: 16 } },
+      { id: 'el-order', key: 'order', type: 'field_row_group', iconName: 'order', label: 'Order', token: 'orderText', x: 13, y: 175, w: 262, h: 33, z: 10, style: { fontSize: 16 } },
+      { id: 'el-supplier', key: 'supplier', type: 'field_row_group', iconName: 'supplier', label: 'Supplier', token: 'supplierText', x: 13, y: 208, w: 262, h: 33, z: 10, style: { fontSize: 16 } },
+      { id: 'el-image', key: 'image', type: 'image', token: 'imageUrl', fit: 'contain', x: 13, y: 246, w: 262, h: 142, z: 5, style: { backgroundColor: '#efefef' } },
+      { id: 'el-notes', key: 'notes', type: 'notes_box', token: 'notesText', x: 13, y: 393, w: 262, h: 24, z: 10, style: { fontSize: 12, color: '#7b7b7b' } },
+      { id: 'el-bottom-bar', key: 'bottom_bar', type: 'rect', x: 13, y: 423, w: 262, h: 17, z: 10, style: { backgroundColor: '#2F6FCC' } },
+      { id: 'el-brand', key: 'brand', type: 'text', text: 'Arda', x: 118, y: 448, w: 52, h: 17, z: 10, style: { fontSize: 15, color: '#e2e2e2', textAlign: 'center' } },
+      { id: 'el-qr-brand', key: 'qr_brand', type: 'text', text: 'Arda', x: 228, y: 77, w: 32, h: 12, z: 11, style: { fontSize: 10, color: '#222222', textAlign: 'center' } },
+    ],
+  };
+}

--- a/apps/web/src/components/printing/designer/template-engine.ts
+++ b/apps/web/src/components/printing/designer/template-engine.ts
@@ -1,0 +1,173 @@
+import type { CardTemplateBindingToken, CardTemplateDefinition, CardTemplateElement } from '@arda/shared-types';
+import type { KanbanPrintData, FormatConfig } from '../types';
+
+const ICON_SVGS: Record<'minimum' | 'location' | 'order' | 'supplier', string> = {
+  minimum:
+    '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#444" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7l9-4 9 4-9 4-9-4z"/><path d="M3 7v10l9 4 9-4V7"/><path d="M12 11v10"/></svg>',
+  location:
+    '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#444" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 1118 0z"/><circle cx="12" cy="10" r="3"/></svg>',
+  order:
+    '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#444" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 3h6v3H9z"/><rect x="6" y="5" width="12" height="16" rx="2"/><path d="M9 11h6"/><path d="M9 15h4"/></svg>',
+  supplier:
+    '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#444" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1 1 0 00.2 1.1l.1.1a1 1 0 010 1.4l-1 1a1 1 0 01-1.4 0l-.1-.1a1 1 0 00-1.1-.2 1 1 0 00-.6.9V20a1 1 0 01-1 1h-1.5a1 1 0 01-1-1v-.1a1 1 0 00-.6-.9 1 1 0 00-1.1.2l-.1.1a1 1 0 01-1.4 0l-1-1a1 1 0 010-1.4l.1-.1a1 1 0 00.2-1.1 1 1 0 00-.9-.6H4a1 1 0 01-1-1v-1.5a1 1 0 011-1h.1a1 1 0 00.9-.6 1 1 0 00-.2-1.1l-.1-.1a1 1 0 010-1.4l1-1a1 1 0 011.4 0l.1.1a1 1 0 001.1.2 1 1 0 00.6-.9V4a1 1 0 011-1h1.5a1 1 0 011 1v.1a1 1 0 00.6.9 1 1 0 001.1-.2l.1-.1a1 1 0 011.4 0l1 1a1 1 0 010 1.4l-.1.1a1 1 0 00-.2 1.1 1 1 0 00.9.6h.1a1 1 0 011 1V13a1 1 0 01-1 1h-.1a1 1 0 00-.9.6z"/></svg>',
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+export function normalizeImageUrl(value?: string): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return parsed.toString();
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveBindingToken(token: CardTemplateBindingToken, data: KanbanPrintData): string {
+  switch (token) {
+    case 'title':
+      return data.partDescription || data.partNumber;
+    case 'sku':
+      return data.sku || data.partNumber;
+    case 'minimumText':
+      return data.minimumText || '';
+    case 'locationText':
+      return data.locationText || '';
+    case 'orderText':
+      return data.orderText || '';
+    case 'supplierText':
+      return data.supplierText || '';
+    case 'notesText':
+      return data.notesText || '';
+    case 'imageUrl':
+      return data.imageUrl || '';
+    case 'qrCodeDataUrl':
+      return data.qrCodeDataUrl || '';
+    default:
+      return '';
+  }
+}
+
+function styleForElement(element: CardTemplateElement): string {
+  const style = element.style ?? {};
+  const declarations = [
+    `position:absolute`,
+    `left:${element.x}px`,
+    `top:${element.y}px`,
+    `width:${element.w}px`,
+    `height:${element.h}px`,
+    `z-index:${element.z}`,
+    `box-sizing:border-box`,
+    `overflow:hidden`,
+  ];
+
+  if (typeof element.rotation === 'number' && element.rotation !== 0) {
+    declarations.push(`transform:rotate(${element.rotation}deg)`);
+    declarations.push('transform-origin:center center');
+  }
+  if (style.fontFamily) declarations.push(`font-family:${style.fontFamily}`);
+  if (style.fontSize) declarations.push(`font-size:${style.fontSize}px`);
+  if (style.fontWeight) declarations.push(`font-weight:${style.fontWeight}`);
+  if (style.color) declarations.push(`color:${style.color}`);
+  if (style.textAlign) declarations.push(`text-align:${style.textAlign}`);
+  if (style.lineHeight) declarations.push(`line-height:${style.lineHeight}`);
+  if (style.backgroundColor) declarations.push(`background:${style.backgroundColor}`);
+  if (style.borderColor && style.borderWidth) declarations.push(`border:${style.borderWidth}px solid ${style.borderColor}`);
+  if (style.borderRadius) declarations.push(`border-radius:${style.borderRadius}px`);
+  if (typeof style.padding === 'number') declarations.push(`padding:${style.padding}px`);
+  if (typeof style.opacity === 'number') declarations.push(`opacity:${style.opacity}`);
+  return declarations.join(';');
+}
+
+function renderElementHtml(element: CardTemplateElement, data: KanbanPrintData): string {
+  const baseStyle = styleForElement(element);
+
+  if (element.type === 'bound_text') {
+    const value = resolveBindingToken(element.token, data) || element.fallbackText || '';
+    return `<div data-el-id="${escapeHtml(element.id)}" style="${baseStyle};white-space:pre-wrap;">${escapeHtml(value)}</div>`;
+  }
+
+  if (element.type === 'text') {
+    return `<div data-el-id="${escapeHtml(element.id)}" style="${baseStyle};white-space:pre-wrap;">${escapeHtml(element.text)}</div>`;
+  }
+
+  if (element.type === 'image') {
+    const resolved = element.token ? resolveBindingToken(element.token, data) : (element.src ?? '');
+    const imageUrl = normalizeImageUrl(resolved);
+    if (!imageUrl) {
+      return `<div data-el-id="${escapeHtml(element.id)}" style="${baseStyle};display:flex;align-items:center;justify-content:center;background:#efefef;color:#8a8a8a;font-size:11px;">No image</div>`;
+    }
+    const fit = element.fit ?? 'contain';
+    return `<div data-el-id="${escapeHtml(element.id)}" style="${baseStyle};display:flex;align-items:center;justify-content:center;"><img src="${escapeHtml(imageUrl)}" alt="Item image" style="display:block;width:100%;height:100%;object-fit:${fit};"/></div>`;
+  }
+
+  if (element.type === 'qr') {
+    return `<div data-el-id="${escapeHtml(element.id)}" style="${baseStyle};"><img src="${escapeHtml(data.qrCodeDataUrl)}" alt="QR Code" style="display:block;width:100%;height:100%;object-fit:contain;"/></div>`;
+  }
+
+  if (element.type === 'icon') {
+    return `<div data-el-id="${escapeHtml(element.id)}" style="${baseStyle};display:flex;align-items:center;justify-content:center;">${ICON_SVGS[element.iconName]}</div>`;
+  }
+
+  if (element.type === 'line') {
+    const stroke = element.style?.strokeColor ?? '#2F6FCC';
+    const width = element.style?.strokeWidth ?? 1;
+    if (element.orientation === 'horizontal') {
+      return `<div data-el-id="${escapeHtml(element.id)}" style="${baseStyle};height:${width}px;background:${stroke};"></div>`;
+    }
+    return `<div data-el-id="${escapeHtml(element.id)}" style="${baseStyle};width:${width}px;background:${stroke};"></div>`;
+  }
+
+  if (element.type === 'rect') {
+    const bg = element.style?.backgroundColor ?? '#2F6FCC';
+    return `<div data-el-id="${escapeHtml(element.id)}" style="${baseStyle};background:${bg};"></div>`;
+  }
+
+  if (element.type === 'notes_box') {
+    const value = element.token ? resolveBindingToken(element.token, data) : data.notesText || '';
+    return `<div data-el-id="${escapeHtml(element.id)}" style="${baseStyle};white-space:pre-wrap;">${escapeHtml(value)}</div>`;
+  }
+
+  if (element.type === 'field_row_group') {
+    const value = resolveBindingToken(element.token, data);
+    return `
+      <div data-el-id="${escapeHtml(element.id)}" style="${baseStyle};display:flex;align-items:flex-start;gap:8px;">
+        <div style="width:30px;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;">
+          ${ICON_SVGS[element.iconName]}
+          <div style="margin-top:2px;font-size:8px;line-height:1;color:#2F6FCC;">${escapeHtml(element.label)}</div>
+        </div>
+        <div style="flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${escapeHtml(value)}</div>
+      </div>
+    `;
+  }
+
+  return '';
+}
+
+export function renderTemplateToHtml(
+  definition: CardTemplateDefinition,
+  data: KanbanPrintData,
+  config: FormatConfig,
+): string {
+  const elements = [...definition.elements].sort((a, b) => a.z - b.z);
+  const children = elements.map((el) => renderElementHtml(el, data)).join('\n');
+
+  return `
+    <div class="print-card" style="position:relative;box-sizing:border-box;width:${config.widthPx}px;height:${config.heightPx}px;background:${escapeHtml(definition.canvas.background)};overflow:hidden;border:1px solid #ddd;font-family:'Open Sans',Arial,sans-serif;">
+      ${children}
+    </div>
+  `;
+}

--- a/apps/web/src/components/printing/designer/template-toolbar.tsx
+++ b/apps/web/src/components/printing/designer/template-toolbar.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { Copy, Redo2, Save, Settings2, Star, Undo2 } from 'lucide-react';
+import { Button, Input } from '@/components/ui';
+
+interface TemplateToolbarProps {
+  templateName: string;
+  onTemplateNameChange: (value: string) => void;
+  onNewTemplate: () => void;
+  onSaveTemplate: () => void;
+  onCloneTemplate: () => void;
+  onSetDefault: () => void;
+  onResetSeed: () => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  isSaving?: boolean;
+  hasSelectedTemplate?: boolean;
+}
+
+export function TemplateToolbar({
+  templateName,
+  onTemplateNameChange,
+  onNewTemplate,
+  onSaveTemplate,
+  onCloneTemplate,
+  onSetDefault,
+  onResetSeed,
+  onUndo,
+  onRedo,
+  canUndo,
+  canRedo,
+  isSaving = false,
+  hasSelectedTemplate = false,
+}: TemplateToolbarProps) {
+  return (
+    <div className="space-y-3 rounded-md border border-border bg-background p-3">
+      <div className="grid gap-2 lg:grid-cols-[minmax(0,1fr)_auto_auto_auto_auto_auto_auto]">
+        <Input
+          value={templateName}
+          onChange={(e) => onTemplateNameChange(e.target.value)}
+          placeholder="Template name"
+        />
+
+        <Button type="button" size="sm" variant="outline" onClick={onNewTemplate}>New</Button>
+
+        <Button type="button" size="sm" variant="outline" onClick={onSaveTemplate} disabled={isSaving}>
+          <Save className="h-3.5 w-3.5" />
+          Save
+        </Button>
+
+        <Button type="button" size="sm" variant="outline" onClick={onCloneTemplate} disabled={!hasSelectedTemplate}>
+          <Copy className="h-3.5 w-3.5" />
+          Duplicate
+        </Button>
+
+        <Button type="button" size="sm" variant="outline" onClick={onSetDefault} disabled={!hasSelectedTemplate}>
+          <Star className="h-3.5 w-3.5" />
+          Set default
+        </Button>
+
+        <Button type="button" size="sm" variant="outline" onClick={onResetSeed}>
+          <Settings2 className="h-3.5 w-3.5" />
+          Reset seed
+        </Button>
+
+        <div className="flex items-center gap-2 lg:justify-end">
+          <Button type="button" size="sm" variant="outline" onClick={onUndo} disabled={!canUndo}>
+            <Undo2 className="h-3.5 w-3.5" />
+            Undo
+          </Button>
+          <Button type="button" size="sm" variant="outline" onClick={onRedo} disabled={!canRedo}>
+            <Redo2 className="h-3.5 w-3.5" />
+            Redo
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/printing/index.ts
+++ b/apps/web/src/components/printing/index.ts
@@ -20,6 +20,7 @@ export {
   buildPrintStylesheet,
   dispatchPrint,
   printCards,
+  downloadCardsPdf,
 } from './print-pipeline';
 export type { PrintSettings, PrintMargins, PrinterClass, ColorMode, Orientation } from './print-pipeline';
 

--- a/apps/web/src/components/printing/kanban-print-renderer.tsx
+++ b/apps/web/src/components/printing/kanban-print-renderer.tsx
@@ -2,11 +2,13 @@
 // Unified entry point that selects the correct template based on format.
 
 import type { CardFormat } from '@arda/shared-types';
+import type { CardTemplateDefinition } from '@arda/shared-types';
 import type { KanbanPrintData } from './types';
 import { FORMAT_CONFIGS } from './types';
 import { KanbanCardTemplate } from './kanban-card-template';
 import { KanbanLabelTemplate } from './kanban-label-template';
 import { OrderCard3x5Template } from './order-card-3x5-template';
+import { renderTemplateToHtml } from './designer/template-engine';
 import { validatePrintData } from './validation';
 
 const CARD_FORMATS: CardFormat[] = ['order_card_3x5_portrait', '3x5_card', '4x6_card', 'business_card'];
@@ -23,9 +25,10 @@ export function isLabelFormat(format: CardFormat): boolean {
 interface KanbanPrintRendererProps {
   data: KanbanPrintData;
   format: CardFormat;
+  templateDefinition?: CardTemplateDefinition;
 }
 
-export function KanbanPrintRenderer({ data, format }: KanbanPrintRendererProps) {
+export function KanbanPrintRenderer({ data, format, templateDefinition }: KanbanPrintRendererProps) {
   const config = FORMAT_CONFIGS[format];
 
   // Validate before rendering
@@ -45,6 +48,9 @@ export function KanbanPrintRenderer({ data, format }: KanbanPrintRendererProps) 
 
   if (isCardFormat(format)) {
     if (config.layoutVariant === 'order_card_3x5_portrait') {
+      if (templateDefinition) {
+        return <div dangerouslySetInnerHTML={{ __html: renderTemplateToHtml(templateDefinition, data, config) }} />;
+      }
       return <OrderCard3x5Template data={data} format={format} config={config} />;
     }
     return <KanbanCardTemplate data={data} format={format} config={config} />;

--- a/apps/web/src/components/printing/order-card-3x5-template.tsx
+++ b/apps/web/src/components/printing/order-card-3x5-template.tsx
@@ -47,22 +47,10 @@ const ICON_SVGS = {
   location:
     '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#444" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 1118 0z"/><circle cx="12" cy="10" r="3"/></svg>',
   order:
-    '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#444" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 3h6v3H9z"/><rect x="6" y="5" width="12" height="16" rx="2"/><path d="M9 11h6"/><path d="M9 15h4"/></svg>',
+    '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#444" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7l9-4 9 4-9 4-9-4z"/><path d="M3 7v10l9 4 9-4V7"/><path d="M12 11v10"/></svg>',
   supplier:
     '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#444" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1 1 0 00.2 1.1l.1.1a1 1 0 010 1.4l-1 1a1 1 0 01-1.4 0l-.1-.1a1 1 0 00-1.1-.2 1 1 0 00-.6.9V20a1 1 0 01-1 1h-1.5a1 1 0 01-1-1v-.1a1 1 0 00-.6-.9 1 1 0 00-1.1.2l-.1.1a1 1 0 01-1.4 0l-1-1a1 1 0 010-1.4l.1-.1a1 1 0 00.2-1.1 1 1 0 00-.9-.6H4a1 1 0 01-1-1v-1.5a1 1 0 011-1h.1a1 1 0 00.9-.6 1 1 0 00-.2-1.1l-.1-.1a1 1 0 010-1.4l1-1a1 1 0 011.4 0l.1.1a1 1 0 001.1.2 1 1 0 00.6-.9V4a1 1 0 011-1h1.5a1 1 0 011 1v.1a1 1 0 00.6.9 1 1 0 001.1-.2l.1-.1a1 1 0 011.4 0l1 1a1 1 0 010 1.4l-.1.1a1 1 0 00-.2 1.1 1 1 0 00.9.6h.1a1 1 0 011 1V13a1 1 0 01-1 1h-.1a1 1 0 00-.9.6z"/></svg>',
 };
-
-function normalizeImageUrl(value: string | undefined): string | null {
-  if (!value) return null;
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  try {
-    const parsed = new URL(trimmed);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed.toString() : null;
-  } catch {
-    return null;
-  }
-}
 
 function buildOrderCard3x5LayoutModel(data: KanbanPrintData, config: FormatConfig): OrderCard3x5LayoutModel {
   const accentColor = normalizeColor(data.accentColor);
@@ -150,13 +138,12 @@ export function renderOrderCard3x5Html(data: KanbanPrintData, config: FormatConf
   const titleHtml = model.titleLines.map((line) => escapeHtml(line)).join('<br/>');
   const skuHtml = model.skuLines.map((line) => escapeHtml(line)).join('<br/>');
   const notesHtml = model.notesLines.map((line) => escapeHtml(line)).join('<br/>');
-  const normalizedImageUrl = normalizeImageUrl(data.imageUrl);
-  const imageHtml = normalizedImageUrl
-    ? `<img src="${escapeHtml(normalizedImageUrl)}" alt="Item image" style="display:block;max-width:100%;max-height:100%;object-fit:contain;"/>`
+  const imageHtml = data.imageUrl
+    ? `<img src="${escapeHtml(data.imageUrl)}" alt="Item image" style="display:block;max-width:100%;max-height:100%;object-fit:contain;"/>`
     : `<div style="display:flex;align-items:center;justify-content:center;width:100%;height:100%;background:${PLACEHOLDER_BG};color:#8a8a8a;font-size:11px;">No image</div>`;
 
   return `
-    <div class="print-card" style="position:relative;box-sizing:border-box;width:${config.widthPx}px;height:${config.heightPx}px;padding:${config.safeInsetPx}px;background:${CARD_BG};font-family:'Open Sans',Arial,sans-serif;border:1px solid #ddd;overflow:hidden;display:flex;flex-direction:column;">
+    <div class="print-card" style="position:relative;box-sizing:border-box;width:${config.widthPx}px;height:${config.heightPx}px;padding:${config.safeInsetPx}px;background:${CARD_BG};font-family:'Open Sans',Arial,sans-serif;border:1px solid #ddd;overflow:hidden;">
       <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:10px;">
         <div style="flex:1;min-width:0;">
           <div style="font-size:${model.titleFontSizePx}px;font-weight:700;line-height:1.1;color:#111;max-height:72px;overflow:hidden;">${titleHtml}</div>
@@ -173,16 +160,16 @@ export function renderOrderCard3x5Html(data: KanbanPrintData, config: FormatConf
         ${model.fields.map(renderFieldRow).join('')}
       </div>
 
-      <div style="margin-top:8px;flex:1;min-height:120px;display:flex;align-items:center;justify-content:center;">
+      <div style="margin-top:10px;height:166px;display:flex;align-items:center;justify-content:center;">
         ${imageHtml}
       </div>
 
-      <div style="margin-top:4px;min-height:20px;font-size:${model.notesFontSizePx}px;line-height:1.2;color:#7b7b7b;overflow:hidden;">
+      <div style="margin-top:3px;height:22px;font-size:${model.notesFontSizePx}px;line-height:1.2;color:#7b7b7b;overflow:hidden;">
         ${notesHtml}
       </div>
 
-      <div style="margin-top:4px;height:17px;background:${model.accentColor};"></div>
-      <div style="margin-top:6px;text-align:center;font-size:15px;line-height:1;color:#e2e2e2;">Arda</div>
+      <div style="margin-top:6px;height:17px;background:${model.accentColor};"></div>
+      <div style="margin-top:8px;text-align:center;font-size:15px;line-height:1;color:#e2e2e2;">Arda</div>
     </div>
   `;
 }

--- a/apps/web/src/types/shared-types.d.ts
+++ b/apps/web/src/types/shared-types.d.ts
@@ -8,4 +8,121 @@ declare module "@arda/shared-types" {
     | "1x3_label"
     | "bin_label"
     | "1x1_label";
+
+  export const CARD_TEMPLATE_SCHEMA_VERSION: 1;
+  export type CardTemplateSchemaVersion = typeof CARD_TEMPLATE_SCHEMA_VERSION;
+  export type CardTemplateStatus = "active" | "archived";
+  export type CardTemplateBindingToken =
+    | "title"
+    | "sku"
+    | "minimumText"
+    | "locationText"
+    | "orderText"
+    | "supplierText"
+    | "notesText"
+    | "imageUrl"
+    | "qrCodeDataUrl";
+
+  export interface CardTemplateElementStyle {
+    fontFamily?: string;
+    fontSize?: number;
+    fontWeight?: number;
+    color?: string;
+    textAlign?: "left" | "center" | "right";
+    lineHeight?: number;
+    backgroundColor?: string;
+    borderColor?: string;
+    borderWidth?: number;
+    borderRadius?: number;
+    padding?: number;
+    opacity?: number;
+    strokeColor?: string;
+    strokeWidth?: number;
+  }
+
+  export interface CardTemplateBaseElement {
+    id: string;
+    key?: string;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    z: number;
+    rotation?: number;
+    locked?: boolean;
+    style?: CardTemplateElementStyle;
+  }
+
+  export interface CardTemplateBoundTextElement extends CardTemplateBaseElement {
+    type: "bound_text";
+    token: CardTemplateBindingToken;
+    fallbackText?: string;
+  }
+  export interface CardTemplateTextElement extends CardTemplateBaseElement {
+    type: "text";
+    text: string;
+  }
+  export interface CardTemplateImageElement extends CardTemplateBaseElement {
+    type: "image";
+    token?: Extract<CardTemplateBindingToken, "imageUrl">;
+    src?: string;
+    fit?: "contain" | "cover";
+  }
+  export interface CardTemplateQrElement extends CardTemplateBaseElement {
+    type: "qr";
+  }
+  export interface CardTemplateIconElement extends CardTemplateBaseElement {
+    type: "icon";
+    iconName: "minimum" | "location" | "order" | "supplier";
+  }
+  export interface CardTemplateLineElement extends CardTemplateBaseElement {
+    type: "line";
+    orientation: "horizontal" | "vertical";
+  }
+  export interface CardTemplateRectElement extends CardTemplateBaseElement {
+    type: "rect";
+  }
+  export interface CardTemplateNotesBoxElement extends CardTemplateBaseElement {
+    type: "notes_box";
+    token?: Extract<CardTemplateBindingToken, "notesText">;
+  }
+  export interface CardTemplateFieldRowGroupElement extends CardTemplateBaseElement {
+    type: "field_row_group";
+    iconName: "minimum" | "location" | "order" | "supplier";
+    label: string;
+    token: Extract<CardTemplateBindingToken, "minimumText" | "locationText" | "orderText" | "supplierText">;
+  }
+  export type CardTemplateElement =
+    | CardTemplateBoundTextElement
+    | CardTemplateTextElement
+    | CardTemplateImageElement
+    | CardTemplateQrElement
+    | CardTemplateIconElement
+    | CardTemplateLineElement
+    | CardTemplateRectElement
+    | CardTemplateNotesBoxElement
+    | CardTemplateFieldRowGroupElement;
+
+  export interface CardTemplateDefinition {
+    version: CardTemplateSchemaVersion;
+    canvas: { width: number; height: number; background: string };
+    grid: { enabled: boolean; size: number; snapThreshold: number };
+    safeArea: { top: number; right: number; bottom: number; left: number };
+    requiredElementKeys: string[];
+    elements: CardTemplateElement[];
+  }
+
+  export interface CardTemplateRecord {
+    id: string;
+    tenantId: string;
+    name: string;
+    format: CardFormat;
+    isDefault: boolean;
+    status: CardTemplateStatus;
+    definition: CardTemplateDefinition;
+    createdByUserId?: string | null;
+    updatedByUserId?: string | null;
+    createdAt: string;
+    updatedAt: string;
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,8 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "html2canvas": "^1.4.1",
+        "jspdf": "^4.1.0",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.4.6",
         "react": "^18.3.1",
@@ -1370,6 +1372,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -6847,6 +6858,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/pg": {
       "version": "8.6.1",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
@@ -6889,6 +6906,13 @@
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -6975,6 +6999,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -7816,6 +7847,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -8126,6 +8166,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -8429,6 +8489,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+      "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -8506,6 +8578,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -8812,6 +8893,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -10215,6 +10306,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -10255,6 +10357,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -10803,6 +10911,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -11017,6 +11138,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/ioredis": {
       "version": "5.9.2",
@@ -11345,6 +11472,23 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/jspdf": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.1.0.tgz",
+      "integrity": "sha512-xd1d/XRkwqnsq6FP3zH1Q+Ejqn2ULIJeDZ+FTKpaabVpZREjsJKRJwuokTNgdqOU+fl55KgbvgZ1pRTSWCP2kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -12142,6 +12286,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -12223,6 +12373,13 @@
       "funding": {
         "url": "https://ko-fi.com/killymxi"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -12902,6 +13059,16 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -13217,6 +13384,13 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -13351,6 +13525,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -13887,6 +14071,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
@@ -14124,6 +14318,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/svix": {
       "version": "1.84.1",
       "resolved": "https://registry.npmjs.org/svix/-/svix-1.84.1.tgz",
@@ -14225,6 +14429,15 @@
       "license": "MIT",
       "dependencies": {
         "bintrees": "1.0.2"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/thenify": {
@@ -14728,6 +14941,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/packages/db/drizzle/0007_card_templates.sql
+++ b/packages/db/drizzle/0007_card_templates.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "kanban"."card_templates" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "tenant_id" uuid NOT NULL,
+  "name" varchar(120) NOT NULL,
+  "format" varchar(50) NOT NULL,
+  "is_default" boolean NOT NULL DEFAULT false,
+  "status" varchar(20) NOT NULL DEFAULT 'active',
+  "definition" jsonb NOT NULL,
+  "created_by_user_id" uuid,
+  "updated_by_user_id" uuid,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE INDEX "card_templates_tenant_fmt_status_idx"
+  ON "kanban"."card_templates" USING btree ("tenant_id", "format", "status");
+
+CREATE INDEX "card_templates_tenant_default_idx"
+  ON "kanban"."card_templates" USING btree ("tenant_id", "format", "is_default");
+
+CREATE UNIQUE INDEX "card_templates_default_active_unique_idx"
+  ON "kanban"."card_templates" USING btree ("tenant_id", "format")
+  WHERE "is_default" = true AND "status" = 'active';

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1771023600000,
       "tag": "0006_supplier_order_terms",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1771102800000,
+      "tag": "0007_card_templates",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/tenants.ts
+++ b/packages/db/src/schema/tenants.ts
@@ -47,6 +47,7 @@ export interface TenantSettings {
   requireApprovalForPO?: boolean;
   autoConsolidateOrders?: boolean;
   reloWisaEnabled?: boolean;
+  cardTemplateDesignerEnabled?: boolean;
   webhookUrl?: string;
   webhookSecret?: string;
   webhookEvents?: string[];

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -200,6 +200,145 @@ export type CardFormat =
   | 'bin_label'
   | '1x1_label';
 
+export const CARD_TEMPLATE_SCHEMA_VERSION = 1 as const;
+export type CardTemplateSchemaVersion = typeof CARD_TEMPLATE_SCHEMA_VERSION;
+export type CardTemplateStatus = 'active' | 'archived';
+export type CardTemplateBindingToken =
+  | 'title'
+  | 'sku'
+  | 'minimumText'
+  | 'locationText'
+  | 'orderText'
+  | 'supplierText'
+  | 'notesText'
+  | 'imageUrl'
+  | 'qrCodeDataUrl';
+
+export interface CardTemplateElementStyle {
+  fontFamily?: string;
+  fontSize?: number;
+  fontWeight?: number;
+  color?: string;
+  textAlign?: 'left' | 'center' | 'right';
+  lineHeight?: number;
+  backgroundColor?: string;
+  borderColor?: string;
+  borderWidth?: number;
+  borderRadius?: number;
+  padding?: number;
+  opacity?: number;
+  strokeColor?: string;
+  strokeWidth?: number;
+}
+
+export interface CardTemplateBaseElement {
+  id: string;
+  key?: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  z: number;
+  rotation?: number;
+  locked?: boolean;
+  style?: CardTemplateElementStyle;
+}
+
+export interface CardTemplateBoundTextElement extends CardTemplateBaseElement {
+  type: 'bound_text';
+  token: CardTemplateBindingToken;
+  fallbackText?: string;
+}
+
+export interface CardTemplateTextElement extends CardTemplateBaseElement {
+  type: 'text';
+  text: string;
+}
+
+export interface CardTemplateImageElement extends CardTemplateBaseElement {
+  type: 'image';
+  token?: Extract<CardTemplateBindingToken, 'imageUrl'>;
+  src?: string;
+  fit?: 'contain' | 'cover';
+}
+
+export interface CardTemplateQrElement extends CardTemplateBaseElement {
+  type: 'qr';
+}
+
+export interface CardTemplateIconElement extends CardTemplateBaseElement {
+  type: 'icon';
+  iconName: 'minimum' | 'location' | 'order' | 'supplier';
+}
+
+export interface CardTemplateLineElement extends CardTemplateBaseElement {
+  type: 'line';
+  orientation: 'horizontal' | 'vertical';
+}
+
+export interface CardTemplateRectElement extends CardTemplateBaseElement {
+  type: 'rect';
+}
+
+export interface CardTemplateNotesBoxElement extends CardTemplateBaseElement {
+  type: 'notes_box';
+  token?: Extract<CardTemplateBindingToken, 'notesText'>;
+}
+
+export interface CardTemplateFieldRowGroupElement extends CardTemplateBaseElement {
+  type: 'field_row_group';
+  iconName: 'minimum' | 'location' | 'order' | 'supplier';
+  label: string;
+  token: Extract<CardTemplateBindingToken, 'minimumText' | 'locationText' | 'orderText' | 'supplierText'>;
+}
+
+export type CardTemplateElement =
+  | CardTemplateBoundTextElement
+  | CardTemplateTextElement
+  | CardTemplateImageElement
+  | CardTemplateQrElement
+  | CardTemplateIconElement
+  | CardTemplateLineElement
+  | CardTemplateRectElement
+  | CardTemplateNotesBoxElement
+  | CardTemplateFieldRowGroupElement;
+
+export interface CardTemplateDefinition {
+  version: CardTemplateSchemaVersion;
+  canvas: {
+    width: number;
+    height: number;
+    background: string;
+  };
+  grid: {
+    enabled: boolean;
+    size: number;
+    snapThreshold: number;
+  };
+  safeArea: {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+  };
+  requiredElementKeys: string[];
+  elements: CardTemplateElement[];
+}
+
+export interface CardTemplateRecord {
+  id: string;
+  tenantId: string;
+  name: string;
+  format: CardFormat;
+  isDefault: boolean;
+  status: CardTemplateStatus;
+  definition: CardTemplateDefinition;
+  createdByUserId?: string | null;
+  updatedByUserId?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 // ─── Print Job Types ────────────────────────────────────────────────
 export type PrintJobStatus = 'pending' | 'printing' | 'completed' | 'failed' | 'cancelled';
 
@@ -555,4 +694,37 @@ export interface BatchReplayResponse {
   succeeded: number;
   failed: number;
   results: ScanReplayResult[];
+}
+
+// ─── Lead Time Aggregate Stats (for MVP-10/T3) ─────────────────────
+export interface LeadTimeAggregateStats {
+  avgLeadTimeDays: number;
+  medianLeadTimeDays: number;
+  p90LeadTimeDays: number;
+  minLeadTimeDays: number;
+  maxLeadTimeDays: number;
+  transferCount: number;
+}
+
+export interface LeadTimeTrendDataPoint {
+  date: string; // ISO date (YYYY-MM-DD)
+  avgLeadTimeDays: number;
+  transferCount: number;
+}
+
+export interface LeadTimeTrendData {
+  data: LeadTimeTrendDataPoint[];
+  summary: {
+    overallAvg: number;
+    totalTransfers: number;
+    dateRange: { from: string; to: string };
+  };
+}
+
+export interface LeadTimeFilters {
+  sourceFacilityId?: string;
+  destinationFacilityId?: string;
+  partId?: string;
+  dateFrom?: string; // ISO date string
+  dateTo?: string; // ISO date string
 }

--- a/services/auth/src/routes/tenant.routes.ts
+++ b/services/auth/src/routes/tenant.routes.ts
@@ -57,6 +57,7 @@ tenantRouter.patch(
             requireApprovalForPO: z.boolean().optional(),
             autoConsolidateOrders: z.boolean().optional(),
             reloWisaEnabled: z.boolean().optional(),
+            cardTemplateDesignerEnabled: z.boolean().optional(),
           })
           .optional(),
       });

--- a/services/kanban/src/index.ts
+++ b/services/kanban/src/index.ts
@@ -13,6 +13,7 @@ import { scanRouter } from './routes/scan.routes.js';
 import { velocityRouter } from './routes/velocity.routes.js';
 import { printJobsRouter } from './routes/print-jobs.routes.js';
 import { lifecycleRouter } from './routes/lifecycle.routes.js';
+import { cardTemplatesRouter } from './routes/card-templates.routes.js';
 import { errorHandler } from './middleware/error-handler.js';
 import { initScanDedupeManager, getScanDedupeManager } from './services/card-lifecycle.service.js';
 
@@ -53,6 +54,7 @@ app.use('/cards', cardsRouter);
 app.use('/velocity', velocityRouter);
 app.use('/print-jobs', printJobsRouter);
 app.use('/lifecycle', lifecycleRouter);
+app.use('/card-templates', cardTemplatesRouter);
 
 app.use(errorHandler);
 

--- a/services/kanban/src/routes/card-templates.routes.test.ts
+++ b/services/kanban/src/routes/card-templates.routes.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { CardTemplateDefinition } from '@arda/shared-types';
+import { _validateTemplateDefinitionForTests } from './card-templates.routes.js';
+
+function buildValidDefinition(): CardTemplateDefinition {
+  return {
+    version: 1,
+    canvas: { width: 288, height: 480, background: '#eeeeee' },
+    grid: { enabled: true, size: 8, snapThreshold: 4 },
+    safeArea: { top: 13, right: 13, bottom: 13, left: 13 },
+    requiredElementKeys: [
+      'title',
+      'sku',
+      'qr',
+      'minimum',
+      'location',
+      'order',
+      'supplier',
+      'image',
+      'notes',
+      'top_line',
+      'bottom_bar',
+    ],
+    elements: [
+      { id: 'title', key: 'title', type: 'bound_text', token: 'title', x: 13, y: 13, w: 160, h: 60, z: 1 },
+      { id: 'sku', key: 'sku', type: 'bound_text', token: 'sku', x: 13, y: 76, w: 160, h: 20, z: 2 },
+      { id: 'qr', key: 'qr', type: 'qr', x: 213, y: 13, w: 62, h: 62, z: 2 },
+      { id: 'minimum', key: 'minimum', type: 'field_row_group', iconName: 'minimum', label: 'Minimum', token: 'minimumText', x: 13, y: 105, w: 262, h: 34, z: 3 },
+      { id: 'location', key: 'location', type: 'field_row_group', iconName: 'location', label: 'Location', token: 'locationText', x: 13, y: 140, w: 262, h: 34, z: 3 },
+      { id: 'order', key: 'order', type: 'field_row_group', iconName: 'order', label: 'Order', token: 'orderText', x: 13, y: 175, w: 262, h: 34, z: 3 },
+      { id: 'supplier', key: 'supplier', type: 'field_row_group', iconName: 'supplier', label: 'Supplier', token: 'supplierText', x: 13, y: 210, w: 262, h: 34, z: 3 },
+      { id: 'image', key: 'image', type: 'image', token: 'imageUrl', fit: 'contain', x: 13, y: 250, w: 262, h: 130, z: 2 },
+      { id: 'notes', key: 'notes', type: 'notes_box', token: 'notesText', x: 13, y: 386, w: 262, h: 28, z: 2 },
+      { id: 'top_line', key: 'top_line', type: 'line', orientation: 'horizontal', x: 13, y: 98, w: 262, h: 1, z: 1 },
+      { id: 'bottom_bar', key: 'bottom_bar', type: 'rect', x: 13, y: 420, w: 262, h: 17, z: 1 },
+    ],
+  };
+}
+
+describe('card template definition validation', () => {
+  it('accepts a valid template definition', () => {
+    expect(() => _validateTemplateDefinitionForTests(buildValidDefinition())).not.toThrow();
+  });
+
+  it('rejects missing required key registrations', () => {
+    const def = buildValidDefinition();
+    def.requiredElementKeys = def.requiredElementKeys.filter((key) => key !== 'qr');
+    expect(() => _validateTemplateDefinitionForTests(def)).toThrow(/requiredElementKeys entry: qr/);
+  });
+
+  it('rejects out-of-bounds elements', () => {
+    const def = buildValidDefinition();
+    def.elements[0] = { ...def.elements[0], x: 0 } as CardTemplateDefinition['elements'][number];
+    expect(() => _validateTemplateDefinitionForTests(def)).toThrow(/outside safe bounds/);
+  });
+});

--- a/services/kanban/src/routes/card-templates.routes.ts
+++ b/services/kanban/src/routes/card-templates.routes.ts
@@ -1,0 +1,467 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { and, desc, eq, ne } from 'drizzle-orm';
+import { db, schema } from '@arda/db';
+import type { AuthRequest } from '@arda/auth-utils';
+import type { CardFormat, CardTemplateDefinition, CardTemplateElement } from '@arda/shared-types';
+import { AppError } from '../middleware/error-handler.js';
+
+export const cardTemplatesRouter = Router();
+const { cardTemplates } = schema;
+
+const CARD_TEMPLATE_REQUIRED_KEYS = [
+  'title',
+  'sku',
+  'qr',
+  'minimum',
+  'location',
+  'order',
+  'supplier',
+  'image',
+  'notes',
+  'top_line',
+  'bottom_bar',
+] as const;
+
+const tokenSchema = z.enum([
+  'title',
+  'sku',
+  'minimumText',
+  'locationText',
+  'orderText',
+  'supplierText',
+  'notesText',
+  'imageUrl',
+  'qrCodeDataUrl',
+]);
+
+const styleSchema = z.object({
+  fontFamily: z.string().max(100).optional(),
+  fontSize: z.number().min(6).max(120).optional(),
+  fontWeight: z.number().min(100).max(900).optional(),
+  color: z.string().max(30).optional(),
+  textAlign: z.enum(['left', 'center', 'right']).optional(),
+  lineHeight: z.number().min(0.5).max(4).optional(),
+  backgroundColor: z.string().max(30).optional(),
+  borderColor: z.string().max(30).optional(),
+  borderWidth: z.number().min(0).max(20).optional(),
+  borderRadius: z.number().min(0).max(100).optional(),
+  padding: z.number().min(0).max(100).optional(),
+  opacity: z.number().min(0).max(1).optional(),
+  strokeColor: z.string().max(30).optional(),
+  strokeWidth: z.number().min(0).max(20).optional(),
+}).optional();
+
+const baseElementSchema = z.object({
+  id: z.string().min(1).max(120),
+  key: z.string().min(1).max(120).optional(),
+  x: z.number().min(0),
+  y: z.number().min(0),
+  w: z.number().min(1),
+  h: z.number().min(1),
+  z: z.number().int().min(0).max(9999),
+  rotation: z.number().min(-360).max(360).optional(),
+  locked: z.boolean().optional(),
+  style: styleSchema,
+});
+
+const elementSchema = z.discriminatedUnion('type', [
+  baseElementSchema.extend({
+    type: z.literal('bound_text'),
+    token: tokenSchema,
+    fallbackText: z.string().max(500).optional(),
+  }),
+  baseElementSchema.extend({
+    type: z.literal('text'),
+    text: z.string().max(5_000),
+  }),
+  baseElementSchema.extend({
+    type: z.literal('image'),
+    token: z.literal('imageUrl').optional(),
+    src: z.string().url().optional(),
+    fit: z.enum(['contain', 'cover']).optional(),
+  }),
+  baseElementSchema.extend({
+    type: z.literal('qr'),
+  }),
+  baseElementSchema.extend({
+    type: z.literal('icon'),
+    iconName: z.enum(['minimum', 'location', 'order', 'supplier']),
+  }),
+  baseElementSchema.extend({
+    type: z.literal('line'),
+    orientation: z.enum(['horizontal', 'vertical']),
+  }),
+  baseElementSchema.extend({
+    type: z.literal('rect'),
+  }),
+  baseElementSchema.extend({
+    type: z.literal('notes_box'),
+    token: z.literal('notesText').optional(),
+  }),
+  baseElementSchema.extend({
+    type: z.literal('field_row_group'),
+    iconName: z.enum(['minimum', 'location', 'order', 'supplier']),
+    label: z.string().max(120),
+    token: z.enum(['minimumText', 'locationText', 'orderText', 'supplierText']),
+  }),
+]);
+
+const definitionSchema: z.ZodType<CardTemplateDefinition> = z.object({
+  version: z.literal(1),
+  canvas: z.object({
+    width: z.number().int().positive().max(2_000),
+    height: z.number().int().positive().max(2_000),
+    background: z.string().max(30),
+  }),
+  grid: z.object({
+    enabled: z.boolean(),
+    size: z.number().int().min(2).max(200),
+    snapThreshold: z.number().min(0).max(100),
+  }),
+  safeArea: z.object({
+    top: z.number().min(0).max(500),
+    right: z.number().min(0).max(500),
+    bottom: z.number().min(0).max(500),
+    left: z.number().min(0).max(500),
+  }),
+  requiredElementKeys: z.array(z.string().min(1).max(120)).min(1).max(200),
+  elements: z.array(elementSchema).min(1).max(200),
+});
+
+const createTemplateSchema = z.object({
+  name: z.string().trim().min(1).max(120),
+  format: z.enum(['order_card_3x5_portrait']) as z.ZodType<CardFormat>,
+  definition: definitionSchema,
+  makeDefault: z.boolean().optional(),
+});
+
+const updateTemplateSchema = z.object({
+  name: z.string().trim().min(1).max(120).optional(),
+  definition: definitionSchema.optional(),
+  status: z.enum(['active', 'archived']).optional(),
+});
+
+const listTemplateSchema = z.object({
+  format: z.enum(['order_card_3x5_portrait']).default('order_card_3x5_portrait'),
+});
+
+function validateDefinition(definition: CardTemplateDefinition): void {
+  const requiredSet = new Set(definition.requiredElementKeys);
+  for (const required of CARD_TEMPLATE_REQUIRED_KEYS) {
+    if (!requiredSet.has(required)) {
+      throw new AppError(400, `Missing requiredElementKeys entry: ${required}`);
+    }
+  }
+
+  const presentKeys = new Set(
+    definition.elements
+      .map((element) => element.key)
+      .filter((key): key is string => !!key),
+  );
+
+  for (const required of CARD_TEMPLATE_REQUIRED_KEYS) {
+    if (!presentKeys.has(required)) {
+      throw new AppError(400, `Missing required element key in elements[]: ${required}`);
+    }
+  }
+
+  const maxX = definition.canvas.width - definition.safeArea.right;
+  const maxY = definition.canvas.height - definition.safeArea.bottom;
+
+  for (const element of definition.elements) {
+    const left = element.x;
+    const top = element.y;
+    const right = element.x + element.w;
+    const bottom = element.y + element.h;
+
+    if (left < definition.safeArea.left || top < definition.safeArea.top || right > maxX || bottom > maxY) {
+      throw new AppError(400, `Element ${element.id} is outside safe bounds`);
+    }
+  }
+}
+
+async function setDefaultTemplate(
+  tenantId: string,
+  templateId: string,
+  format: CardFormat,
+  updatedByUserId: string,
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx
+      .update(cardTemplates)
+      .set({
+        isDefault: false,
+        updatedByUserId,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(cardTemplates.tenantId, tenantId),
+          eq(cardTemplates.format, format),
+          eq(cardTemplates.status, 'active'),
+          eq(cardTemplates.isDefault, true),
+          ne(cardTemplates.id, templateId),
+        ),
+      );
+
+    const [updated] = await tx
+      .update(cardTemplates)
+      .set({
+        isDefault: true,
+        status: 'active',
+        updatedByUserId,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(cardTemplates.id, templateId),
+          eq(cardTemplates.tenantId, tenantId),
+        ),
+      )
+      .returning();
+
+    if (!updated) {
+      throw new AppError(404, 'Template not found');
+    }
+  });
+}
+
+cardTemplatesRouter.get('/', async (req: AuthRequest, res, next) => {
+  try {
+    const tenantId = req.user!.tenantId;
+    const query = listTemplateSchema.parse(req.query);
+
+    const rows = await db
+      .select()
+      .from(cardTemplates)
+      .where(
+        and(
+          eq(cardTemplates.tenantId, tenantId),
+          eq(cardTemplates.format, query.format),
+          eq(cardTemplates.status, 'active'),
+        ),
+      )
+      .orderBy(desc(cardTemplates.updatedAt));
+
+    const currentDefaultId = rows.find((row) => row.isDefault)?.id ?? null;
+    res.json({ data: rows, currentDefaultId });
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ error: 'Validation error', details: err.errors });
+      return;
+    }
+    next(err);
+  }
+});
+
+cardTemplatesRouter.post('/', async (req: AuthRequest, res, next) => {
+  try {
+    const tenantId = req.user!.tenantId;
+    const userId = req.user!.sub;
+    const input = createTemplateSchema.parse(req.body);
+    validateDefinition(input.definition);
+
+    let createdId: string | null = null;
+
+    await db.transaction(async (tx) => {
+      if (input.makeDefault) {
+        await tx
+          .update(cardTemplates)
+          .set({
+            isDefault: false,
+            updatedByUserId: userId,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(cardTemplates.tenantId, tenantId),
+              eq(cardTemplates.format, input.format),
+              eq(cardTemplates.status, 'active'),
+              eq(cardTemplates.isDefault, true),
+            ),
+          );
+      }
+
+      const [created] = await tx
+        .insert(cardTemplates)
+        .values({
+          tenantId,
+          name: input.name,
+          format: input.format,
+          isDefault: input.makeDefault ?? false,
+          status: 'active',
+          definition: input.definition as unknown as Record<string, unknown>,
+          createdByUserId: userId,
+          updatedByUserId: userId,
+        })
+        .returning();
+
+      createdId = created.id;
+    });
+
+    if (!createdId) {
+      throw new AppError(500, 'Failed to create template');
+    }
+
+    const [created] = await db
+      .select()
+      .from(cardTemplates)
+      .where(and(eq(cardTemplates.id, createdId), eq(cardTemplates.tenantId, tenantId)));
+
+    res.status(201).json(created);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ error: 'Validation error', details: err.errors });
+      return;
+    }
+    next(err);
+  }
+});
+
+cardTemplatesRouter.patch('/:id', async (req: AuthRequest, res, next) => {
+  try {
+    const tenantId = req.user!.tenantId;
+    const userId = req.user!.sub;
+    const templateId = req.params.id as string;
+    const input = updateTemplateSchema.parse(req.body);
+
+    if (Object.keys(input).length === 0) {
+      throw new AppError(400, 'No updates provided');
+    }
+
+    if (input.definition) {
+      validateDefinition(input.definition);
+    }
+
+    const updateData: Record<string, unknown> = {
+      updatedAt: new Date(),
+      updatedByUserId: userId,
+    };
+
+    if (input.name !== undefined) updateData.name = input.name;
+    if (input.status !== undefined) {
+      updateData.status = input.status;
+      if (input.status === 'archived') updateData.isDefault = false;
+    }
+    if (input.definition !== undefined) {
+      updateData.definition = input.definition as unknown as Record<string, unknown>;
+    }
+
+    const [updated] = await db
+      .update(cardTemplates)
+      .set(updateData)
+      .where(and(eq(cardTemplates.id, templateId), eq(cardTemplates.tenantId, tenantId)))
+      .returning();
+
+    if (!updated) {
+      throw new AppError(404, 'Template not found');
+    }
+
+    res.json(updated);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ error: 'Validation error', details: err.errors });
+      return;
+    }
+    next(err);
+  }
+});
+
+cardTemplatesRouter.post('/:id/set-default', async (req: AuthRequest, res, next) => {
+  try {
+    const tenantId = req.user!.tenantId;
+    const userId = req.user!.sub;
+    const templateId = req.params.id as string;
+
+    const [row] = await db
+      .select({ id: cardTemplates.id, format: cardTemplates.format })
+      .from(cardTemplates)
+      .where(and(eq(cardTemplates.id, templateId), eq(cardTemplates.tenantId, tenantId)));
+
+    if (!row) {
+      throw new AppError(404, 'Template not found');
+    }
+
+    await setDefaultTemplate(tenantId, templateId, row.format as CardFormat, userId);
+
+    const [updated] = await db
+      .select()
+      .from(cardTemplates)
+      .where(and(eq(cardTemplates.id, templateId), eq(cardTemplates.tenantId, tenantId)));
+
+    res.json(updated);
+  } catch (err) {
+    next(err);
+  }
+});
+
+cardTemplatesRouter.post('/:id/clone', async (req: AuthRequest, res, next) => {
+  try {
+    const tenantId = req.user!.tenantId;
+    const userId = req.user!.sub;
+    const templateId = req.params.id as string;
+
+    const [source] = await db
+      .select()
+      .from(cardTemplates)
+      .where(and(eq(cardTemplates.id, templateId), eq(cardTemplates.tenantId, tenantId)));
+
+    if (!source) {
+      throw new AppError(404, 'Template not found');
+    }
+
+    const [created] = await db
+      .insert(cardTemplates)
+      .values({
+        tenantId,
+        name: `${source.name} (Copy)`,
+        format: source.format,
+        isDefault: false,
+        status: 'active',
+        definition: source.definition,
+        createdByUserId: userId,
+        updatedByUserId: userId,
+      })
+      .returning();
+
+    res.status(201).json(created);
+  } catch (err) {
+    next(err);
+  }
+});
+
+cardTemplatesRouter.delete('/:id', async (req: AuthRequest, res, next) => {
+  try {
+    const tenantId = req.user!.tenantId;
+    const userId = req.user!.sub;
+    const templateId = req.params.id as string;
+
+    const [updated] = await db
+      .update(cardTemplates)
+      .set({
+        status: 'archived',
+        isDefault: false,
+        updatedByUserId: userId,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(cardTemplates.id, templateId), eq(cardTemplates.tenantId, tenantId)))
+      .returning();
+
+    if (!updated) {
+      throw new AppError(404, 'Template not found');
+    }
+
+    res.json({ success: true, id: updated.id });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export function _validateTemplateDefinitionForTests(definition: CardTemplateDefinition): void {
+  validateDefinition(definition);
+}
+
+export function _templateElementSchemaForTests(): z.ZodType<CardTemplateElement> {
+  return elementSchema as unknown as z.ZodType<CardTemplateElement>;
+}

--- a/services/kanban/src/routes/print-jobs.routes.ts
+++ b/services/kanban/src/routes/print-jobs.routes.ts
@@ -31,6 +31,7 @@ const createPrintJobSchema = z.object({
     }).optional(),
     colorMode: z.enum(['color', 'monochrome']).optional(),
     orientation: z.enum(['portrait', 'landscape']).optional(),
+    templateId: z.string().uuid().optional(),
   }).optional(),
 });
 


### PR DESCRIPTION
## Summary
- Add tenant-shared card templates for `order_card_3x5_portrait` with backend CRUD/default/clone/archive APIs.
- Add inline drag-and-drop WYSIWYG template designer in Item Detail > Card Editor behind dual feature gates.
- Add unified template render path for preview + print and pass template ID into print job settings.
- Add explicit PDF download from the same render path.
- Keep legacy editor fallback path available via rollout switch.

## Backend
- New migration/table: `kanban.card_templates`
- New routes: `/api/kanban/card-templates`
- Print-jobs settings now accept `templateId`
- Tenant settings extended with `cardTemplateDesignerEnabled`

## Frontend
- New designer canvas/toolbox/inspector/toolbar components
- Template selector + save/duplicate/default/archive flows
- Per-print data overrides and image URL save support
- Template-aware print dispatch + PDF export (`html2canvas` + `jspdf`)

## Verification
- ✅ `npm run -w @arda/shared-types build`
- ✅ `npm run -w @arda/db build`
- ✅ `npm run -w @arda/kanban-service typecheck`
- ✅ `npm run -w @arda/auth-service typecheck`
- ✅ `npm run -w @arda/web build`
- ✅ `npm run -w @arda/web test -- src/components/item-detail/__tests__/card-label-designer.test.ts src/components/printing/__tests__/print-pipeline.test.ts src/lib/kanban-printing.test.ts`
- ⚠️ `npm run -w @arda/web test -- src/lib/api-client.test.ts` has 2 existing failures unrelated to this feature (lifecycle card summary normalization + compatibility alias retry assertion).
