### PR TITLE
fix(flags): enable card template designer by default in prod

### DIFF
--- a/apps/web/src/components/item-detail/card-label-designer.tsx
+++ b/apps/web/src/components/item-detail/card-label-designer.tsx
@@ -50,8 +50,9 @@ const CARD_PREVIEW_LOAD_TIMEOUT_MS = 20_000;
 const DEFAULT_ACCENT = "#2F6FCC";
 
 function isTemplateDesignerEnvEnabled(): boolean {
+  if (import.meta.env.PROD) return true;
   const raw = import.meta.env.VITE_ENABLE_CARD_TEMPLATE_DESIGNER;
-  if (typeof raw !== "string") return false;
+  if (typeof raw !== "string" || raw.trim().length === 0) return false;
   return raw.toLowerCase() === "true" || raw === "1";
 }
 
@@ -170,14 +171,16 @@ export function CardLabelDesigner({
       try {
         const tenant = await fetchCurrentTenant(token);
         if (cancelled) return;
-        setIsTemplateDesignerEnabled(Boolean(tenant.settings?.cardTemplateDesignerEnabled));
+        const setting = tenant.settings?.cardTemplateDesignerEnabled;
+        setIsTemplateDesignerEnabled(typeof setting === "boolean" ? setting : true);
       } catch (error) {
         if (isUnauthorized(error)) {
           onUnauthorized();
           return;
         }
         if (!cancelled) {
-          setIsTemplateDesignerEnabled(false);
+          // Default on in production if tenant settings fail to load.
+          setIsTemplateDesignerEnabled(Boolean(import.meta.env.PROD));
         }
       }
     }

--- a/services/auth/src/routes/tenant.routes.ts
+++ b/services/auth/src/routes/tenant.routes.ts
@@ -22,6 +22,11 @@ tenantRouter.get('/current', async (req: AuthRequest, res, next) => {
       return;
     }
 
+    const effectiveSettings: schema.TenantSettings = {
+      ...(tenant.settings ?? {}),
+      cardTemplateDesignerEnabled: true,
+    };
+
     res.json({
       id: tenant.id,
       name: tenant.name,
@@ -30,7 +35,7 @@ tenantRouter.get('/current', async (req: AuthRequest, res, next) => {
       planId: tenant.planId,
       cardLimit: tenant.cardLimit,
       seatLimit: tenant.seatLimit,
-      settings: tenant.settings,
+      settings: effectiveSettings,
       createdAt: tenant.createdAt,
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
Enable the Card Template Designer by default in production so users can immediately access the new WYSIWYG editor.

## Changes
- Web gate: `CardLabelDesigner` now enables template designer automatically in production builds.
- Tenant gate: `/api/tenants/current` now returns `settings.cardTemplateDesignerEnabled = true` in effective settings.
- Keeps existing local/dev gate behavior for explicit testing.

## Verification
- `npm run -w @arda/auth-service typecheck`
- `npm run -w @arda/web build`
- `npm run -w @arda/web test -- src/components/item-detail/__tests__/card-label-designer.test.ts`
