### PR TITLE
feat(#218): define v2 realtime contracts and ws event catalog

### DIFF
--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -3,6 +3,26 @@ import { createLogger } from '@arda/config';
 
 const log = createLogger('event-bus');
 
+// ─── Event Envelope (Protocol v2) ───────────────────────────────────
+export interface EventMeta {
+  id: string;
+  schemaVersion: number;
+  source: string;
+  correlationId?: string;
+  timestamp: string;
+  replayed?: boolean;
+}
+
+export interface EventEnvelope<T extends ArdaEvent = ArdaEvent> {
+  id: string;
+  schemaVersion: number;
+  source: string;
+  correlationId?: string;
+  timestamp: string;
+  replayed?: boolean;
+  event: T;
+}
+
 // ─── Event Types ────────────────────────────────────────────────────
 export interface CardTransitionEvent {
   type: 'card.transition';
@@ -77,6 +97,45 @@ export interface NotificationEvent {
   notificationId: string;
   notificationType: string;
   title: string;
+  timestamp: string;
+}
+
+// ─── Realtime Analytics / Audit / Activity Events ───────────────────
+export interface KpiRefreshedEvent {
+  type: 'kpi.refreshed';
+  tenantId: string;
+  kpiKey: string;
+  window: '30d' | '60d' | '90d' | 'custom';
+  facilityId?: string;
+  value: number;
+  previousValue?: number;
+  deltaPercent?: number;
+  refreshedAt: string;
+  timestamp: string;
+}
+
+export interface AuditCreatedEvent {
+  type: 'audit.created';
+  tenantId: string;
+  auditId: string;
+  action: string;
+  entityType: string;
+  entityId: string | null;
+  actorUserId?: string | null;
+  method?: 'manual' | 'system' | 'scan' | 'api';
+  timestamp: string;
+}
+
+export interface UserActivityEvent {
+  type: 'user.activity';
+  tenantId: string;
+  userId: string;
+  activityType: 'login' | 'logout' | 'page_view' | 'command' | 'mutation' | 'websocket_subscribe';
+  route?: string;
+  resourceType?: string;
+  resourceId?: string;
+  sessionId?: string;
+  correlationId?: string;
   timestamp: string;
 }
 
@@ -380,6 +439,9 @@ export type ArdaEvent =
   | ReloWisaRecommendationEvent
   | QueueRiskDetectedEvent
   | NotificationEvent
+  | KpiRefreshedEvent
+  | AuditCreatedEvent
+  | UserActivityEvent
   | SecurityEvent
   | LifecycleTransitionEvent
   | LifecycleTransitionRejectedEvent

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -472,20 +472,46 @@ export const ROUTING_STEP_VALID_TRANSITIONS: Record<RoutingStepStatus, RoutingSt
 };
 
 // ─── WebSocket Events ────────────────────────────────────────────────
-export type WSEventType =
-  | 'card:stage_changed'
-  | 'card:triggered'
-  | 'po:status_changed'
-  | 'wo:status_changed'
-  | 'transfer:status_changed'
-  | 'inventory:updated'
-  | 'notification:new'
-  | 'relowisa:recommendation'
-  | 'wo:step_completed'
-  | 'wo:quantity_reported'
-  | 'wo:expedited'
-  | 'wo:held'
-  | 'wo:resumed';
+export type RealtimeProtocolVersion = '1' | '2';
+
+export const WS_EVENT_TYPES = [
+  // Control events
+  'connected',
+  'pong',
+  'error',
+  // Core lifecycle + order events
+  'card:stage_changed',
+  'card:triggered',
+  'po:status_changed',
+  'wo:status_changed',
+  'transfer:status_changed',
+  // Production events
+  'wo:step_completed',
+  'wo:quantity_reported',
+  'wo:expedited',
+  'wo:held',
+  'wo:resumed',
+  // Receiving events
+  'receiving:completed',
+  'receiving:exception_created',
+  'receiving:exception_resolved',
+  // Automation events
+  'automation:po_created',
+  'automation:to_created',
+  'automation:email_dispatched',
+  'automation:shopping_list_item_added',
+  'automation:card_stage_changed',
+  'automation:escalated',
+  // Realtime surfaces
+  'notification:new',
+  'relowisa:recommendation',
+  'kpi:refreshed',
+  'audit:created',
+  'user:activity',
+  'inventory:updated',
+] as const;
+
+export type WSEventType = (typeof WS_EVENT_TYPES)[number];
 
 export interface WSEvent<T = unknown> {
   type: WSEventType;
@@ -493,6 +519,83 @@ export interface WSEvent<T = unknown> {
   payload: T;
   timestamp: string;
 }
+
+export interface RealtimeHandshakeAuth {
+  token: string;
+  protocolVersion?: RealtimeProtocolVersion;
+  lastEventId?: string;
+}
+
+export interface RealtimeConnectedPayload {
+  tenantId: string;
+  userId: string;
+  timestamp: string;
+  protocolVersion?: RealtimeProtocolVersion;
+  lastEventId?: string;
+}
+
+export interface RealtimePingPayload {
+  timestamp?: string;
+}
+
+export interface RealtimePongPayload {
+  timestamp: string;
+}
+
+export interface RealtimeErrorPayload {
+  message: string;
+  code?: string;
+  retryable?: boolean;
+}
+
+export interface RealtimeSubscribeLoopPayload {
+  loopId: string;
+  protocolVersion?: RealtimeProtocolVersion;
+  lastEventId?: string;
+}
+
+export interface RealtimeUnsubscribeLoopPayload {
+  loopId: string;
+}
+
+export type RealtimeControlEventType = 'connected' | 'pong' | 'error';
+
+export interface RealtimeControlEvent {
+  type: RealtimeControlEventType;
+  payload: RealtimeConnectedPayload | RealtimePongPayload | RealtimeErrorPayload;
+}
+
+// Compile-time coverage: ensures every WSEventType has a mapped key.
+export const WS_EVENT_TYPE_COVERAGE: Record<WSEventType, true> = {
+  connected: true,
+  pong: true,
+  error: true,
+  'card:stage_changed': true,
+  'card:triggered': true,
+  'po:status_changed': true,
+  'wo:status_changed': true,
+  'transfer:status_changed': true,
+  'wo:step_completed': true,
+  'wo:quantity_reported': true,
+  'wo:expedited': true,
+  'wo:held': true,
+  'wo:resumed': true,
+  'receiving:completed': true,
+  'receiving:exception_created': true,
+  'receiving:exception_resolved': true,
+  'automation:po_created': true,
+  'automation:to_created': true,
+  'automation:email_dispatched': true,
+  'automation:shopping_list_item_added': true,
+  'automation:card_stage_changed': true,
+  'automation:escalated': true,
+  'notification:new': true,
+  'relowisa:recommendation': true,
+  'kpi:refreshed': true,
+  'audit:created': true,
+  'user:activity': true,
+  'inventory:updated': true,
+};
 
 // ─── Transfer Lifecycle ──────────────────────────────────────────────
 export const TRANSFER_VALID_TRANSITIONS: Record<TransferStatus, TransferStatus[]> = {


### PR DESCRIPTION
## Summary
- adds protocol-v2 envelope contracts in `@arda/events` (`EventMeta`, `EventEnvelope<T>`) with FR-01 fields
- extends `ArdaEvent` with new realtime domain events: `kpi.refreshed`, `audit.created`, `user.activity`
- expands `WSEventType` in `@arda/shared-types` to cover production, receiving, automation, control, and new realtime surfaces (including `inventory:updated`)
- adds shared protocol-v2 handshake/control payload types with optional `lastEventId` and `protocolVersion`
- adds compile-time event-type coverage map (`WS_EVENT_TYPE_COVERAGE`) to enforce assignability across all websocket event literals

## Acceptance Criteria Mapping
- [x] `EventEnvelope<T>` and `EventMeta` are added in `packages/events/src/index.ts`
- [x] New events `kpi.refreshed`, `audit.created`, and `user.activity` are added to `ArdaEvent`
- [x] `WSEventType` includes production/receiving/automation/new/control additions, including `inventory:updated`
- [x] Shared handshake/realtime payload types for protocol v2 are exported with optional `lastEventId` and `protocolVersion`
- [x] Type-level assignability coverage added via `WS_EVENT_TYPE_COVERAGE: Record<WSEventType, true>`

## Validation
- `npm run -w @arda/events typecheck`
- `npm run -w @arda/events lint`
- `npm run -w @arda/events test`
- `npm run -w @arda/shared-types typecheck`
- `npm run -w @arda/shared-types lint`

Closes #218
