### PR TITLE
feat(#221): implement websocket replay + resync control flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16378,6 +16378,7 @@
         "express-rate-limit": "^7.5.0",
         "helmet": "^8.0.0",
         "http-proxy-middleware": "^3.0.0",
+        "ioredis": "^5.4.0",
         "multer": "^1.4.5-lts.1",
         "socket.io": "^4.8.1"
       },

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -546,6 +546,8 @@ export const WS_EVENT_TYPES = [
   'connected',
   'pong',
   'error',
+  'replay_complete',
+  'resync_required',
   // Core lifecycle + order events
   'card:stage_changed',
   'card:triggered',
@@ -615,6 +617,19 @@ export interface RealtimeErrorPayload {
   retryable?: boolean;
 }
 
+export interface RealtimeReplayCompletePayload {
+  replayedCount: number;
+  lastEventId: string;
+  protocolVersion?: RealtimeProtocolVersion;
+}
+
+export interface RealtimeResyncRequiredPayload {
+  reason: 'stale_last_event_id' | 'replay_failed';
+  lastEventId?: string;
+  replayTtlMs?: number;
+  protocolVersion?: RealtimeProtocolVersion;
+}
+
 export interface RealtimeSubscribeLoopPayload {
   loopId: string;
   protocolVersion?: RealtimeProtocolVersion;
@@ -625,11 +640,21 @@ export interface RealtimeUnsubscribeLoopPayload {
   loopId: string;
 }
 
-export type RealtimeControlEventType = 'connected' | 'pong' | 'error';
+export type RealtimeControlEventType =
+  | 'connected'
+  | 'pong'
+  | 'error'
+  | 'replay_complete'
+  | 'resync_required';
 
 export interface RealtimeControlEvent {
   type: RealtimeControlEventType;
-  payload: RealtimeConnectedPayload | RealtimePongPayload | RealtimeErrorPayload;
+  payload:
+    | RealtimeConnectedPayload
+    | RealtimePongPayload
+    | RealtimeErrorPayload
+    | RealtimeReplayCompletePayload
+    | RealtimeResyncRequiredPayload;
 }
 
 // Compile-time coverage: ensures every WSEventType has a mapped key.
@@ -637,6 +662,8 @@ export const WS_EVENT_TYPE_COVERAGE: Record<WSEventType, true> = {
   connected: true,
   pong: true,
   error: true,
+  replay_complete: true,
+  resync_required: true,
   'card:stage_changed': true,
   'card:triggered': true,
   'po:status_changed': true,

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -26,6 +26,7 @@
     "express-rate-limit": "^7.5.0",
     "helmet": "^8.0.0",
     "http-proxy-middleware": "^3.0.0",
+    "ioredis": "^5.4.0",
     "multer": "^1.4.5-lts.1",
     "socket.io": "^4.8.1"
   },

--- a/services/api-gateway/src/ws/replay-service.test.ts
+++ b/services/api-gateway/src/ws/replay-service.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import type { ArdaEvent } from '@arda/events';
+
+vi.mock('@arda/config', () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+  }),
+}));
+
+vi.mock('@arda/events', () => ({
+  getTenantStream: (tenantId: string) => `arda:stream:${tenantId}`,
+}));
+
+import { ReplayService, type ReplayControlEmitter, type ReplayRedisClient } from './replay-service.js';
+
+type StreamReadResult = Awaited<ReturnType<ReplayRedisClient['xread']>>;
+
+function createRedisClient(reads: StreamReadResult[]): ReplayRedisClient & {
+  xread: ReturnType<typeof vi.fn>;
+  quit: ReturnType<typeof vi.fn>;
+} {
+  const queue = [...reads];
+  const xread = vi.fn(async () => queue.shift() ?? null);
+  const quit = vi.fn(async () => 'OK');
+
+  return {
+    xread,
+    quit,
+  };
+}
+
+function createEmitter(): {
+  emitter: ReplayControlEmitter;
+  emitEvent: ReturnType<typeof vi.fn>;
+  emitControl: ReturnType<typeof vi.fn>;
+} {
+  const emitEvent = vi.fn();
+  const emitControl = vi.fn();
+
+  return {
+    emitter: {
+      emitEvent: emitEvent as ReplayControlEmitter['emitEvent'],
+      emitControl: emitControl as ReplayControlEmitter['emitControl'],
+    },
+    emitEvent,
+    emitControl,
+  };
+}
+
+function cardTransitionEvent(overrides: Partial<ArdaEvent> = {}): ArdaEvent {
+  return {
+    type: 'card.transition',
+    tenantId: 'tenant-1',
+    cardId: 'card-1',
+    loopId: 'loop-1',
+    fromStage: 'created',
+    toStage: 'triggered',
+    method: 'scan',
+    timestamp: '2026-02-15T00:00:00.000Z',
+    ...overrides,
+  } as ArdaEvent;
+}
+
+describe('ReplayService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-15T00:15:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('skips replay when lastEventId is missing', async () => {
+    const redis = createRedisClient([]);
+    const { emitter, emitEvent, emitControl } = createEmitter();
+    const service = new ReplayService('redis://unused', {}, redis);
+
+    const result = await service.replayMissedEvents({ tenantId: 'tenant-1' }, emitter);
+
+    expect(result).toEqual({ status: 'skipped', replayedCount: 0 });
+    expect(redis.xread).not.toHaveBeenCalled();
+    expect(emitEvent).not.toHaveBeenCalled();
+    expect(emitControl).not.toHaveBeenCalled();
+  });
+
+  it('emits resync_required when lastEventId is outside replay TTL', async () => {
+    const redis = createRedisClient([]);
+    const { emitter, emitControl } = createEmitter();
+    const service = new ReplayService('redis://unused', { replayTtlMs: 1_000 }, redis);
+
+    const result = await service.replayMissedEvents(
+      {
+        tenantId: 'tenant-1',
+        lastEventId: '1739578440000-0',
+        protocolVersion: '2',
+      },
+      emitter,
+    );
+
+    expect(result).toEqual({ status: 'resync_required', replayedCount: 0 });
+    expect(redis.xread).not.toHaveBeenCalled();
+    expect(emitControl).toHaveBeenCalledWith('resync_required', {
+      reason: 'stale_last_event_id',
+      lastEventId: '1739578440000-0',
+      replayTtlMs: 1_000,
+      protocolVersion: '2',
+    });
+  });
+
+  it('replays missed events in order and emits replay_complete', async () => {
+    const firstEnvelope = {
+      id: 'evt-1',
+      schemaVersion: 1,
+      source: 'orders-service',
+      timestamp: '2026-02-15T00:14:01.000Z',
+      event: cardTransitionEvent(),
+    };
+    const secondEnvelope = {
+      id: 'evt-2',
+      schemaVersion: 1,
+      source: 'orders-service',
+      timestamp: '2026-02-15T00:14:02.000Z',
+      event: cardTransitionEvent({
+        cardId: 'card-2',
+        toStage: 'ordered',
+      }),
+    };
+    const redis = createRedisClient([
+      [
+        [
+          'arda:stream:tenant-1',
+          [
+            ['1771114441000-0', ['envelope', JSON.stringify(firstEnvelope)]],
+            ['1771114442000-0', ['envelope', JSON.stringify(secondEnvelope)]],
+          ],
+        ],
+      ],
+    ]);
+    const { emitter, emitEvent, emitControl } = createEmitter();
+    const service = new ReplayService('redis://unused', {}, redis);
+
+    const result = await service.replayMissedEvents(
+      {
+        tenantId: 'tenant-1',
+        lastEventId: '1771114440000-0',
+        protocolVersion: '2',
+      },
+      emitter,
+    );
+
+    expect(result).toEqual({
+      status: 'completed',
+      replayedCount: 2,
+      lastDeliveredEventId: '1771114442000-0',
+    });
+    expect(emitEvent).toHaveBeenNthCalledWith(1, {
+      type: 'card:triggered',
+      tenantId: 'tenant-1',
+      payload: firstEnvelope.event,
+      timestamp: '2026-02-15T00:00:00.000Z',
+      replayed: true,
+      eventId: 'evt-1',
+    });
+    expect(emitEvent).toHaveBeenNthCalledWith(2, {
+      type: 'card:stage_changed',
+      tenantId: 'tenant-1',
+      payload: secondEnvelope.event,
+      timestamp: '2026-02-15T00:00:00.000Z',
+      replayed: true,
+      eventId: 'evt-2',
+    });
+    expect(emitControl).toHaveBeenCalledWith('replay_complete', {
+      replayedCount: 2,
+      lastEventId: '1771114442000-0',
+      protocolVersion: '2',
+    });
+  });
+});

--- a/services/api-gateway/src/ws/replay-service.ts
+++ b/services/api-gateway/src/ws/replay-service.ts
@@ -1,0 +1,168 @@
+import { Redis } from 'ioredis';
+import { createLogger } from '@arda/config';
+import { getTenantStream, type ArdaEvent, type EventEnvelope } from '@arda/events';
+import type {
+  RealtimeProtocolVersion,
+  RealtimeReplayCompletePayload,
+  RealtimeResyncRequiredPayload,
+} from '@arda/shared-types';
+import type { GatewayWSEvent } from './event-mapper.js';
+import { mapBackendEventToWSEvent } from './event-mapper.js';
+
+const log = createLogger('ws:replay');
+
+const DEFAULT_REPLAY_TTL_MS = 15 * 60 * 1000;
+const DEFAULT_REPLAY_BATCH_SIZE = 200;
+
+type StreamEntry = [id: string, fields: string[]];
+type StreamReadResult = Array<[stream: string, entries: StreamEntry[]]> | null;
+
+export interface ReplayRedisClient {
+  xread: (...args: unknown[]) => Promise<StreamReadResult>;
+  quit: () => Promise<unknown>;
+}
+
+export interface ReplayControlEmitter {
+  emitEvent: (event: GatewayWSEvent & { replayed: true; eventId: string }) => void;
+  emitControl(type: 'replay_complete', payload: RealtimeReplayCompletePayload): void;
+  emitControl(type: 'resync_required', payload: RealtimeResyncRequiredPayload): void;
+}
+
+export interface ReplayRequest {
+  tenantId: string;
+  lastEventId?: string;
+  protocolVersion?: RealtimeProtocolVersion;
+}
+
+export interface ReplayResult {
+  status: 'skipped' | 'completed' | 'resync_required';
+  replayedCount: number;
+  lastDeliveredEventId?: string;
+}
+
+export interface ReplayServiceOptions {
+  replayTtlMs?: number;
+  batchSize?: number;
+}
+
+function parseStreamIdMs(streamId: string): number | null {
+  const idPart = streamId.split('-')[0];
+  const ms = Number(idPart);
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  return ms;
+}
+
+function isStaleEventId(lastEventId: string, replayTtlMs: number): boolean {
+  const idMs = parseStreamIdMs(lastEventId);
+  if (idMs === null) return true;
+  return Date.now() - idMs > replayTtlMs;
+}
+
+function getField(fields: string[], key: string): string | undefined {
+  for (let i = 0; i < fields.length - 1; i += 2) {
+    if (fields[i] === key) return fields[i + 1];
+  }
+  return undefined;
+}
+
+export class ReplayService {
+  private readonly redis: ReplayRedisClient;
+  private readonly ownsRedis: boolean;
+  private readonly replayTtlMs: number;
+  private readonly batchSize: number;
+
+  constructor(
+    redisUrl: string,
+    options: ReplayServiceOptions = {},
+    redisClient?: ReplayRedisClient,
+  ) {
+    this.redis = (redisClient ?? new Redis(redisUrl)) as ReplayRedisClient;
+    this.ownsRedis = !redisClient;
+    this.replayTtlMs = options.replayTtlMs ?? DEFAULT_REPLAY_TTL_MS;
+    this.batchSize = options.batchSize ?? DEFAULT_REPLAY_BATCH_SIZE;
+  }
+
+  async close(): Promise<void> {
+    if (this.ownsRedis) {
+      await this.redis.quit();
+    }
+  }
+
+  async replayMissedEvents(
+    request: ReplayRequest,
+    emitter: ReplayControlEmitter,
+  ): Promise<ReplayResult> {
+    const { tenantId, lastEventId, protocolVersion } = request;
+    if (!lastEventId) {
+      return { status: 'skipped', replayedCount: 0 };
+    }
+
+    if (isStaleEventId(lastEventId, this.replayTtlMs)) {
+      emitter.emitControl('resync_required', {
+        reason: 'stale_last_event_id',
+        lastEventId,
+        replayTtlMs: this.replayTtlMs,
+        protocolVersion,
+      });
+      return { status: 'resync_required', replayedCount: 0 };
+    }
+
+    const streamKey = getTenantStream(tenantId);
+    let cursor = lastEventId;
+    let replayedCount = 0;
+    let lastDeliveredEventId: string | undefined;
+
+    while (true) {
+      const rows = await this.redis.xread(
+        'COUNT',
+        String(this.batchSize),
+        'STREAMS',
+        streamKey,
+        cursor,
+      );
+
+      const entries = rows?.[0]?.[1] ?? [];
+      if (entries.length === 0) break;
+
+      for (const [streamId, fields] of entries) {
+        cursor = streamId;
+        lastDeliveredEventId = streamId;
+
+        const rawEnvelope = getField(fields, 'envelope');
+        if (!rawEnvelope) continue;
+
+        let envelope: EventEnvelope<ArdaEvent>;
+        try {
+          envelope = JSON.parse(rawEnvelope) as EventEnvelope<ArdaEvent>;
+        } catch (err) {
+          log.warn({ err, streamId, tenantId }, 'Skipping malformed envelope in replay stream');
+          continue;
+        }
+
+        const mapped = mapBackendEventToWSEvent(envelope.event);
+        if (!mapped) continue;
+
+        emitter.emitEvent({
+          ...mapped,
+          replayed: true,
+          eventId: envelope.id,
+        });
+        replayedCount += 1;
+      }
+
+      if (entries.length < this.batchSize) break;
+    }
+
+    emitter.emitControl('replay_complete', {
+      replayedCount,
+      lastEventId: lastDeliveredEventId ?? lastEventId,
+      protocolVersion,
+    });
+
+    return {
+      status: 'completed',
+      replayedCount,
+      lastDeliveredEventId: lastDeliveredEventId ?? lastEventId,
+    };
+  }
+}

--- a/services/api-gateway/src/ws/socket-handler.ts
+++ b/services/api-gateway/src/ws/socket-handler.ts
@@ -5,7 +5,9 @@ import { config, createLogger } from '@arda/config';
 import { getEventBus, type ArdaEvent } from '@arda/events';
 import { db, schema } from '@arda/db';
 import { eq, and } from 'drizzle-orm';
+import type { RealtimeProtocolVersion } from '@arda/shared-types';
 import { mapBackendEventToWSEvent } from './event-mapper.js';
+import { ReplayService } from './replay-service.js';
 
 interface AuthenticatedSocket extends Socket {
   user: JwtPayload;
@@ -13,12 +15,23 @@ interface AuthenticatedSocket extends Socket {
 
 const log = createLogger('ws');
 
+type ReplayMode = 'replaying' | 'flushing' | 'live';
+
+interface ReplayHandshakeOptions {
+  lastEventId?: string;
+  protocolVersion?: RealtimeProtocolVersion;
+}
+
 interface TenantRoomEmitter {
   to: (room: string) => { emit: (eventName: string, payload: unknown) => void };
 }
 
 interface MappingLogger {
   debug: (context: Record<string, unknown>, message: string) => void;
+}
+
+interface SocketEventEmitter {
+  emit: (eventName: string, payload: unknown) => void;
 }
 
 export function emitMappedTenantEvent(
@@ -37,6 +50,46 @@ export function emitMappedTenantEvent(
   return true;
 }
 
+export function emitMappedSocketEvent(
+  socket: SocketEventEmitter,
+  event: ArdaEvent,
+  logger: MappingLogger = log,
+): boolean {
+  const mapped = mapBackendEventToWSEvent(event);
+  if (!mapped) {
+    logger.debug({ eventType: event.type }, 'Ignoring non-forwarded backend event');
+    return false;
+  }
+
+  socket.emit(mapped.type, mapped);
+  return true;
+}
+
+function parseOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseProtocolVersion(value: unknown): RealtimeProtocolVersion | undefined {
+  if (value === '1' || value === '2') return value;
+  return undefined;
+}
+
+export function parseReplayHandshakeOptions(auth: unknown): ReplayHandshakeOptions {
+  if (!auth || typeof auth !== 'object') return {};
+
+  const candidate = auth as {
+    lastEventId?: unknown;
+    protocolVersion?: unknown;
+  };
+
+  return {
+    lastEventId: parseOptionalString(candidate.lastEventId),
+    protocolVersion: parseProtocolVersion(candidate.protocolVersion),
+  };
+}
+
 export function setupWebSocket(httpServer: HttpServer, redisUrl: string): SocketServer {
   const io = new SocketServer(httpServer, {
     cors: {
@@ -50,6 +103,7 @@ export function setupWebSocket(httpServer: HttpServer, redisUrl: string): Socket
   });
 
   const eventBus = getEventBus(redisUrl);
+  const replayService = new ReplayService(redisUrl);
 
   // Auth middleware — verify JWT from handshake
   io.use(async (socket, next) => {
@@ -69,6 +123,10 @@ export function setupWebSocket(httpServer: HttpServer, redisUrl: string): Socket
   io.on('connection', (socket) => {
     const user = (socket as AuthenticatedSocket).user;
     const tenantId = user.tenantId;
+    const replayHandshake = parseReplayHandshakeOptions(socket.handshake.auth);
+    const bufferedLiveEvents: ArdaEvent[] = [];
+    let replayMode: ReplayMode = replayHandshake.lastEventId ? 'replaying' : 'live';
+    let disconnected = false;
 
     log.info({ userId: user.sub, tenantId }, 'Client connected');
 
@@ -76,19 +134,85 @@ export function setupWebSocket(httpServer: HttpServer, redisUrl: string): Socket
     const tenantRoom = `tenant:${tenantId}`;
     socket.join(tenantRoom);
 
-    // Subscribe to tenant events via Redis and forward to Socket.io room
-    const handler = (event: ArdaEvent) => {
-      emitMappedTenantEvent(io, tenantRoom, event);
+    const emitLiveEvent = (event: ArdaEvent): void => {
+      if (disconnected) return;
+      emitMappedSocketEvent(socket, event);
     };
 
-    eventBus.subscribeTenant(tenantId, handler);
+    const flushBufferedLiveEvents = (): void => {
+      replayMode = 'flushing';
+      while (bufferedLiveEvents.length > 0) {
+        const pending = bufferedLiveEvents.splice(0, bufferedLiveEvents.length);
+        for (const event of pending) {
+          emitLiveEvent(event);
+        }
+      }
+      replayMode = 'live';
+    };
+
+    // Subscribe to tenant events and buffer until replay is complete.
+    const handler = (event: ArdaEvent) => {
+      if (replayMode === 'live') {
+        emitLiveEvent(event);
+        return;
+      }
+      bufferedLiveEvents.push(event);
+    };
+
+    void eventBus.subscribeTenant(tenantId, handler).catch((err) => {
+      log.error({ err, tenantId, userId: user.sub }, 'Failed to subscribe tenant event stream');
+      socket.emit('error', {
+        message: 'Failed to subscribe to realtime stream',
+        code: 'REALTIME_SUBSCRIBE_FAILED',
+        retryable: true,
+      });
+    });
 
     // Send welcome message
     socket.emit('connected', {
       tenantId,
       userId: user.sub,
       timestamp: new Date().toISOString(),
+      protocolVersion: replayHandshake.protocolVersion,
+      lastEventId: replayHandshake.lastEventId,
     });
+
+    if (replayHandshake.lastEventId) {
+      void replayService
+        .replayMissedEvents(
+          {
+            tenantId,
+            lastEventId: replayHandshake.lastEventId,
+            protocolVersion: replayHandshake.protocolVersion,
+          },
+          {
+            emitEvent: (event) => {
+              if (disconnected) return;
+              socket.emit(event.type, event);
+            },
+            emitControl: (type, payload) => {
+              if (disconnected) return;
+              socket.emit(type, payload);
+            },
+          },
+        )
+        .catch((err) => {
+          log.error(
+            { err, tenantId, userId: user.sub, lastEventId: replayHandshake.lastEventId },
+            'Failed to replay missed events',
+          );
+          if (!disconnected) {
+            socket.emit('resync_required', {
+              reason: 'replay_failed',
+              lastEventId: replayHandshake.lastEventId,
+              protocolVersion: replayHandshake.protocolVersion,
+            });
+          }
+        })
+        .finally(() => {
+          flushBufferedLiveEvents();
+        });
+    }
 
     // Handle client-side ping (application-level keepalive)
     socket.on('ping', () => {
@@ -120,8 +244,9 @@ export function setupWebSocket(httpServer: HttpServer, redisUrl: string): Socket
     });
 
     socket.on('disconnect', () => {
+      disconnected = true;
       log.info({ userId: user.sub }, 'Client disconnected');
-      eventBus.unsubscribeTenant(tenantId, handler);
+      void eventBus.unsubscribeTenant(tenantId, handler);
     });
   });
 


### PR DESCRIPTION
## Summary
- add tenant-scoped `ReplayService` for Redis Stream missed-event recovery
- extend websocket handshake handling with optional `lastEventId` and `protocolVersion`
- buffer live tenant events during replay and flush after replay completion to avoid transition gaps
- emit `replay_complete` and `resync_required` control events for client reconnection control flow
- add replay service tests for missing-id skip, stale-id resync, and ordered replay completion
- add realtime control payload/type coverage in shared types

## Validation
- npm run -w @arda/shared-types typecheck
- npm run -w @arda/shared-types lint
- npm run -w @arda/shared-types build
- npm run -w @arda/api-gateway typecheck
- npm run -w @arda/api-gateway test
- npm run -w @arda/api-gateway lint

Closes #221
