### PR TITLE
feat(#194): wire approval flow to inventory reservation, kanban triggers, and events

### DIFF
--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -50,7 +50,7 @@ export interface OrderCreatedEvent {
 export interface OrderStatusChangedEvent {
   type: 'order.status_changed';
   tenantId: string;
-  orderType: 'purchase_order' | 'work_order' | 'transfer_order';
+  orderType: 'purchase_order' | 'work_order' | 'transfer_order' | 'sales_order';
   orderId: string;
   orderNumber: string;
   fromStatus: string;
@@ -459,6 +459,50 @@ export interface OrderEmailSentEvent {
   timestamp: string;
 }
 
+// ─── Sales Order Events ──────────────────────────────────────────
+
+export interface SalesOrderApprovedEvent {
+  type: 'sales_order.approved';
+  tenantId: string;
+  orderId: string;
+  orderNumber: string;
+  customerId: string;
+  facilityId: string;
+  lineCount: number;
+  totalAmount: string;
+  reservationSummary: {
+    totalRequested: number;
+    totalReserved: number;
+    shortfallLines: number;
+  };
+  timestamp: string;
+}
+
+export interface SalesOrderCancelledEvent {
+  type: 'sales_order.cancelled';
+  tenantId: string;
+  orderId: string;
+  orderNumber: string;
+  previousStatus: string;
+  cancelReason?: string;
+  inventoryReleased: number;
+  demandSignalsCancelled: number;
+  timestamp: string;
+}
+
+export interface DemandSignalCreatedEvent {
+  type: 'demand_signal.created';
+  tenantId: string;
+  signalId: string;
+  partId: string;
+  facilityId: string;
+  signalType: string;
+  quantityDemanded: number;
+  salesOrderId?: string;
+  salesOrderLineId?: string;
+  timestamp: string;
+}
+
 // Re-export security events
 export {
   type SecurityEvent,
@@ -514,7 +558,10 @@ export type ArdaEvent =
   | OrderIssueCreatedEvent
   | OrderIssueStatusChangedEvent
   | OrderEmailDraftCreatedEvent
-  | OrderEmailSentEvent;
+  | OrderEmailSentEvent
+  | SalesOrderApprovedEvent
+  | SalesOrderCancelledEvent
+  | DemandSignalCreatedEvent;
 
 // ─── Event Channel Names ────────────────────────────────────────────
 const CHANNEL_PREFIX = 'arda:events';

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -556,6 +556,8 @@ export const WS_EVENT_TYPES = [
   'po:status_changed',
   'wo:status_changed',
   'transfer:status_changed',
+  'so:status_changed',
+  'demand_signal:created',
   // Production events
   'wo:step_completed',
   'wo:quantity_reported',
@@ -689,6 +691,8 @@ export const WS_EVENT_TYPE_COVERAGE: Record<WSEventType, true> = {
   'po:status_changed': true,
   'wo:status_changed': true,
   'transfer:status_changed': true,
+  'so:status_changed': true,
+  'demand_signal:created': true,
   'wo:step_completed': true,
   'wo:quantity_reported': true,
   'wo:expedited': true,

--- a/services/api-gateway/src/ws/event-mapper.ts
+++ b/services/api-gateway/src/ws/event-mapper.ts
@@ -28,7 +28,13 @@ export function mapBackendEventToWSEventType(event: ArdaEvent): WSEventType | nu
       if (event.orderType === 'purchase_order') return 'po:status_changed';
       if (event.orderType === 'work_order') return 'wo:status_changed';
       if (event.orderType === 'transfer_order') return 'transfer:status_changed';
+      if (event.orderType === 'sales_order') return 'so:status_changed';
       return null;
+    case 'sales_order.approved':
+    case 'sales_order.cancelled':
+      return 'so:status_changed';
+    case 'demand_signal.created':
+      return 'demand_signal:created';
     case 'production.step_completed':
       return 'wo:step_completed';
     case 'production.quantity_reported':

--- a/services/orders/src/routes/sales-order-approval.integration.test.ts
+++ b/services/orders/src/routes/sales-order-approval.integration.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Integration tests for Sales Order Approval Routes (Ticket #194)
+ *
+ * Tests:
+ * - POST /:id/approve — RBAC + happy path
+ * - POST /:id/cancel-with-release — RBAC + happy path
+ */
+import express from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── Hoisted test state ─────────────────────────────────────────────
+const testState = vi.hoisted(() => ({
+  auditEntries: [] as Array<Record<string, unknown>>,
+}));
+
+// ─── Hoisted DB mock ────────────────────────────────────────────────
+const schemaMock = vi.hoisted(() => ({
+  salesOrders: {},
+  salesOrderLines: {},
+  customers: {},
+  customerContacts: {},
+  customerAddresses: {},
+  demandSignals: {},
+  inventoryLedger: {
+    tenantId: 'tenantId',
+    facilityId: 'facilityId',
+    partId: 'partId',
+    qtyReserved: 'qtyReserved',
+  },
+  kanbanLoops: {},
+  kanbanCards: {},
+}));
+
+const IDS = vi.hoisted(() => ({
+  T: '00000000-0000-0000-0000-000000000001',
+  U: '00000000-0000-0000-0000-000000000011',
+  C: '00000000-0000-0000-0000-000000000021',
+  F: '00000000-0000-0000-0000-000000000031',
+  P: '00000000-0000-0000-0000-000000000041',
+  SO: '00000000-0000-0000-0000-000000000051',
+  L: '00000000-0000-0000-0000-000000000061',
+}));
+
+const { dbMock } = vi.hoisted(() => {
+  const defaultOrder = {
+    id: IDS.SO,
+    tenantId: IDS.T,
+    soNumber: 'SO-20260215-0001',
+    customerId: IDS.C,
+    facilityId: IDS.F,
+    status: 'confirmed',
+    subtotal: '100.00',
+    totalAmount: '100.00',
+    cancelledAt: null,
+    cancelReason: null,
+    createdByUserId: IDS.U,
+  };
+
+  const findFirstMock = vi.fn(async () => ({ ...defaultOrder }));
+
+  const dbMock = {
+    query: {
+      salesOrders: { findFirst: findFirstMock },
+      salesOrderLines: { findFirst: vi.fn() },
+      customers: { findFirst: vi.fn() },
+    },
+    transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb({})),
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    execute: vi.fn(),
+  };
+
+  return { dbMock, findFirstMock, defaultOrder };
+});
+
+// ─── Hoisted mocks ─────────────────────────────────────────────────
+const mockWriteAuditEntry = vi.hoisted(() =>
+  vi.fn(async (_dbOrTx: unknown, entry: Record<string, unknown>) => {
+    testState.auditEntries.push(entry);
+    return { id: 'audit-1', hashChain: 'mock', sequenceNumber: 1 };
+  })
+);
+
+const mockApproveSalesOrder = vi.hoisted(() =>
+  vi.fn(async () => ({
+    orderId: IDS.SO,
+    orderNumber: 'SO-20260215-0001',
+    previousStatus: 'confirmed',
+    newStatus: 'processing',
+    reservations: [{
+      lineId: IDS.L,
+      partId: IDS.P,
+      quantityOrdered: 10,
+      quantityReserved: 10,
+      shortfall: 0,
+    }],
+    demandSignalsCreated: 1,
+    kanbanCardsTriggered: 0,
+  }))
+);
+
+const mockCancelSalesOrder = vi.hoisted(() =>
+  vi.fn(async () => ({
+    orderId: IDS.SO,
+    orderNumber: 'SO-20260215-0001',
+    previousStatus: 'processing',
+    inventoryReleased: 10,
+    demandSignalsCancelled: 1,
+  }))
+);
+
+// ─── Module mocks ───────────────────────────────────────────────────
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(() => ({})),
+  and: vi.fn(() => ({})),
+  or: vi.fn(() => ({})),
+  gte: vi.fn(() => ({})),
+  lte: vi.fn(() => ({})),
+  desc: vi.fn(() => ({})),
+  sql: vi.fn(() => ({})),
+  inArray: vi.fn(() => ({})),
+}));
+
+vi.mock('@arda/db', () => ({
+  db: dbMock,
+  schema: schemaMock,
+  writeAuditEntry: mockWriteAuditEntry,
+  writeAuditEntries: vi.fn(async () => []),
+}));
+
+vi.mock('@arda/config', () => ({
+  config: {},
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock('@arda/shared-types', () => ({
+  SO_VALID_TRANSITIONS: {
+    draft: ['confirmed', 'cancelled'],
+    confirmed: ['processing', 'cancelled'],
+    processing: ['partially_shipped', 'shipped', 'cancelled'],
+    partially_shipped: ['shipped', 'cancelled'],
+    shipped: ['delivered'],
+    delivered: ['invoiced', 'closed'],
+    invoiced: ['closed'],
+    closed: [],
+    cancelled: [],
+  },
+}));
+
+vi.mock('@arda/events', () => ({
+  getEventBus: () => ({ publish: vi.fn(async () => undefined), subscribe: vi.fn() }),
+}));
+
+vi.mock('../services/order-number.service.js', () => ({
+  getNextSONumber: vi.fn(async () => 'SO-20260215-0001'),
+}));
+
+vi.mock('../services/sales-order-approval.service.js', () => ({
+  approveSalesOrder: mockApproveSalesOrder,
+  cancelSalesOrder: mockCancelSalesOrder,
+}));
+
+// ─── Imports ────────────────────────────────────────────────────────
+import { salesOrdersRouter } from './sales-orders.routes.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+interface UserPayload {
+  tenantId: string;
+  sub: string;
+  role: string;
+}
+
+function createApp(user: UserPayload) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as Record<string, unknown>).user = user;
+    next();
+  });
+  app.use('/sales-orders', salesOrdersRouter);
+  app.use((err: { statusCode?: number; message?: string }, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(err?.statusCode ?? 500).json({ error: err?.message ?? 'Internal server error' });
+  });
+  return app;
+}
+
+async function request(
+  app: express.Express,
+  method: string,
+  path: string,
+  body?: object
+) {
+  const server = app.listen(0);
+  try {
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Failed to start test server');
+    const options: RequestInit = {
+      method,
+      headers: { 'content-type': 'application/json' },
+    };
+    if (body) options.body = JSON.stringify(body);
+    const response = await fetch(`http://127.0.0.1:${address.port}${path}`, options);
+    const json = (await response.json()) as Record<string, unknown>;
+    return { status: response.status, body: json };
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+describe('Sales Order Approval Routes', () => {
+  beforeEach(() => {
+    testState.auditEntries.length = 0;
+    mockApproveSalesOrder.mockClear();
+    mockCancelSalesOrder.mockClear();
+  });
+
+  describe('POST /sales-orders/:id/approve', () => {
+    it('should approve a confirmed order (ecommerce_director)', async () => {
+      const app = createApp({ tenantId: IDS.T, sub: IDS.U, role: 'ecommerce_director' });
+
+      const res = await request(app, 'POST', `/sales-orders/${IDS.SO}/approve`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.newStatus).toBe('processing');
+      expect(res.body.reservations).toHaveLength(1);
+      expect(mockApproveSalesOrder).toHaveBeenCalledTimes(1);
+    });
+
+    it('should approve a confirmed order (tenant_admin)', async () => {
+      const app = createApp({ tenantId: IDS.T, sub: IDS.U, role: 'tenant_admin' });
+
+      const res = await request(app, 'POST', `/sales-orders/${IDS.SO}/approve`);
+
+      expect(res.status).toBe(200);
+      expect(mockApproveSalesOrder).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject non-authorized roles (salesperson)', async () => {
+      const app = createApp({ tenantId: IDS.T, sub: IDS.U, role: 'salesperson' });
+
+      const res = await request(app, 'POST', `/sales-orders/${IDS.SO}/approve`);
+
+      expect(res.status).toBe(403);
+      expect(mockApproveSalesOrder).not.toHaveBeenCalled();
+    });
+
+    it('should reject non-authorized roles (inventory_manager)', async () => {
+      const app = createApp({ tenantId: IDS.T, sub: IDS.U, role: 'inventory_manager' });
+
+      const res = await request(app, 'POST', `/sales-orders/${IDS.SO}/approve`);
+
+      expect(res.status).toBe(403);
+      expect(mockApproveSalesOrder).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 for order not found', async () => {
+      (dbMock.query.salesOrders.findFirst as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+      const app = createApp({ tenantId: IDS.T, sub: IDS.U, role: 'ecommerce_director' });
+
+      const res = await request(app, 'POST', `/sales-orders/${IDS.SO}/approve`);
+
+      expect(res.status).toBe(404);
+    });
+
+    it('should forward service errors with correct status code', async () => {
+      mockApproveSalesOrder.mockRejectedValueOnce(
+        Object.assign(new Error('Cannot approve order in "draft" status'), { statusCode: 409 }),
+      );
+      const app = createApp({ tenantId: IDS.T, sub: IDS.U, role: 'ecommerce_director' });
+
+      const res = await request(app, 'POST', `/sales-orders/${IDS.SO}/approve`);
+
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe('POST /sales-orders/:id/cancel-with-release', () => {
+    it('should cancel and release inventory (salesperson)', async () => {
+      const app = createApp({ tenantId: IDS.T, sub: IDS.U, role: 'salesperson' });
+
+      const res = await request(app, 'POST', `/sales-orders/${IDS.SO}/cancel-with-release`, {
+        cancelReason: 'Customer cancelled',
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.inventoryReleased).toBe(10);
+      expect(res.body.demandSignalsCancelled).toBe(1);
+      expect(mockCancelSalesOrder).toHaveBeenCalledTimes(1);
+    });
+
+    it('should cancel and release inventory (tenant_admin)', async () => {
+      const app = createApp({ tenantId: IDS.T, sub: IDS.U, role: 'tenant_admin' });
+
+      const res = await request(app, 'POST', `/sales-orders/${IDS.SO}/cancel-with-release`);
+
+      expect(res.status).toBe(200);
+      expect(mockCancelSalesOrder).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject non-authorized roles (executive)', async () => {
+      const app = createApp({ tenantId: IDS.T, sub: IDS.U, role: 'executive' });
+
+      const res = await request(app, 'POST', `/sales-orders/${IDS.SO}/cancel-with-release`);
+
+      expect(res.status).toBe(403);
+      expect(mockCancelSalesOrder).not.toHaveBeenCalled();
+    });
+
+    it('should forward service errors with correct status code', async () => {
+      mockCancelSalesOrder.mockRejectedValueOnce(
+        Object.assign(new Error('Cannot cancel order in "cancelled" status'), { statusCode: 409 }),
+      );
+      const app = createApp({ tenantId: IDS.T, sub: IDS.U, role: 'salesperson' });
+
+      const res = await request(app, 'POST', `/sales-orders/${IDS.SO}/cancel-with-release`, {
+        cancelReason: 'test',
+      });
+
+      expect(res.status).toBe(409);
+    });
+  });
+});

--- a/services/orders/src/routes/sales-orders.routes.ts
+++ b/services/orders/src/routes/sales-orders.routes.ts
@@ -1,0 +1,815 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { eq, and, sql, gte, lte, desc } from 'drizzle-orm';
+import { db, schema, writeAuditEntry } from '@arda/db';
+import { requireRole, type AuthRequest, type AuditContext } from '@arda/auth-utils';
+import { type SOStatus, SO_VALID_TRANSITIONS } from '@arda/shared-types';
+
+import { AppError } from '../middleware/error-handler.js';
+import { getNextSONumber } from '../services/order-number.service.js';
+import { approveSalesOrder, cancelSalesOrder } from '../services/sales-order-approval.service.js';
+
+const { salesOrders, salesOrderLines, customers } = schema;
+
+function getRequestAuditContext(req: AuthRequest): AuditContext {
+  const forwarded = req.headers['x-forwarded-for'];
+  const forwardedIp = Array.isArray(forwarded)
+    ? forwarded[0]
+    : forwarded?.split(',')[0]?.trim();
+  const rawIp = forwardedIp || req.socket.remoteAddress || undefined;
+  const userAgentHeader = req.headers['user-agent'];
+  const userAgent = Array.isArray(userAgentHeader) ? userAgentHeader[0] : userAgentHeader;
+  return {
+    userId: req.user?.sub,
+    ipAddress: rawIp?.slice(0, 45),
+    userAgent,
+  };
+}
+
+// ─── Validation Schemas ─────────────────────────────────────────────
+
+const soStatusValues = [
+  'draft', 'confirmed', 'processing', 'partially_shipped',
+  'shipped', 'delivered', 'invoiced', 'closed', 'cancelled',
+] as const;
+
+const createLineSchema = z.object({
+  partId: z.string().uuid(),
+  quantityOrdered: z.number().int().positive(),
+  unitPrice: z.number().positive(),
+  discountPercent: z.number().min(0).max(100).default(0),
+  notes: z.string().optional(),
+});
+
+const createSalesOrderSchema = z.object({
+  customerId: z.string().uuid(),
+  facilityId: z.string().uuid(),
+  orderDate: z.string().datetime().optional(),
+  requestedShipDate: z.string().datetime().optional(),
+  shippingAddressId: z.string().uuid().optional(),
+  billingAddressId: z.string().uuid().optional(),
+  paymentTerms: z.string().max(255).optional(),
+  shippingMethod: z.string().max(100).optional(),
+  notes: z.string().optional(),
+  internalNotes: z.string().optional(),
+  lines: z.array(createLineSchema).min(1),
+});
+
+const updateSalesOrderSchema = z.object({
+  requestedShipDate: z.string().datetime().optional(),
+  promisedShipDate: z.string().datetime().optional(),
+  shippingAddressId: z.string().uuid().optional(),
+  billingAddressId: z.string().uuid().optional(),
+  paymentTerms: z.string().max(255).optional(),
+  shippingMethod: z.string().max(100).optional(),
+  trackingNumber: z.string().max(255).optional(),
+  notes: z.string().optional(),
+  internalNotes: z.string().optional(),
+});
+
+const addLineSchema = createLineSchema;
+
+const updateLineSchema = z.object({
+  quantityOrdered: z.number().int().positive().optional(),
+  unitPrice: z.number().positive().optional(),
+  discountPercent: z.number().min(0).max(100).optional(),
+  notes: z.string().optional(),
+});
+
+const listSalesOrdersSchema = z.object({
+  page: z.coerce.number().min(1).default(1),
+  pageSize: z.coerce.number().min(1).max(100).default(25),
+  status: z.enum(soStatusValues).optional(),
+  customerId: z.string().uuid().optional(),
+  dateFrom: z.string().datetime().optional(),
+  dateTo: z.string().datetime().optional(),
+});
+
+const transitionStatusSchema = z.object({
+  cancelReason: z.string().optional(),
+});
+
+// ─── RBAC Definitions ───────────────────────────────────────────────
+// Writers: salesperson (+ tenant_admin via middleware)
+// Readers: salesperson, ecommerce_director (+ tenant_admin via middleware)
+const canRead = requireRole('salesperson', 'ecommerce_director');
+const canWrite = requireRole('salesperson');
+
+export const salesOrdersRouter = Router();
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function tenantScope(req: AuthRequest) {
+  const tenantId = req.user!.tenantId;
+  const conditions = [eq(salesOrders.tenantId, tenantId)];
+  if (req.user!.role === 'salesperson') {
+    conditions.push(eq(salesOrders.createdByUserId, req.user!.sub));
+  }
+  return conditions;
+}
+
+async function findOrderOrThrow(orderId: string, req: AuthRequest) {
+  const conditions = [
+    eq(salesOrders.id, orderId),
+    ...tenantScope(req),
+  ];
+  const order = await db.query.salesOrders.findFirst({
+    where: and(...conditions),
+  });
+  if (!order) {
+    throw new AppError(404, 'Sales order not found');
+  }
+  return order;
+}
+
+function computeLineTotal(qty: number, unitPrice: number, discountPercent: number): string {
+  const gross = qty * unitPrice;
+  const net = gross * (1 - discountPercent / 100);
+  return net.toFixed(2);
+}
+
+function computeOrderTotals(lines: Array<{ lineTotal: string }>) {
+  const subtotal = lines.reduce((sum, l) => sum + parseFloat(l.lineTotal), 0);
+  return { subtotal: subtotal.toFixed(2), totalAmount: subtotal.toFixed(2) };
+}
+
+// ═════════════════════════════════════════════════════════════════════
+//  Sales Order CRUD
+// ═════════════════════════════════════════════════════════════════════
+
+// ─── GET /sales-orders ──────────────────────────────────────────────
+salesOrdersRouter.get('/', canRead, async (req: AuthRequest, res, next) => {
+  try {
+    const query = listSalesOrdersSchema.parse(req.query);
+    const offset = (query.page - 1) * query.pageSize;
+
+    const conditions = tenantScope(req);
+
+    if (query.status) {
+      conditions.push(eq(salesOrders.status, query.status));
+    }
+    if (query.customerId) {
+      conditions.push(eq(salesOrders.customerId, query.customerId));
+    }
+    if (query.dateFrom) {
+      conditions.push(gte(salesOrders.orderDate, new Date(query.dateFrom)));
+    }
+    if (query.dateTo) {
+      conditions.push(lte(salesOrders.orderDate, new Date(query.dateTo)));
+    }
+
+    const whereClause = and(...conditions);
+
+    const [data, countResult] = await Promise.all([
+      db.select()
+        .from(salesOrders)
+        .where(whereClause)
+        .limit(query.pageSize)
+        .offset(offset)
+        .orderBy(desc(salesOrders.createdAt)),
+      db.select({ count: sql<number>`count(*)` })
+        .from(salesOrders)
+        .where(whereClause),
+    ]);
+
+    const total = Number(countResult[0]?.count ?? 0);
+
+    res.json({
+      data,
+      pagination: {
+        page: query.page,
+        pageSize: query.pageSize,
+        total,
+        totalPages: Math.ceil(total / query.pageSize),
+      },
+    });
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ error: 'Invalid query parameters', details: err.errors });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── GET /sales-orders/:id ──────────────────────────────────────────
+salesOrdersRouter.get('/:id', canRead, async (req: AuthRequest, res, next) => {
+  try {
+    const conditions = [
+      eq(salesOrders.id, req.params.id as string),
+      ...tenantScope(req),
+    ];
+    const order = await db.query.salesOrders.findFirst({
+      where: and(...conditions),
+      with: {
+        customer: true,
+        lines: true,
+        shippingAddress: true,
+        billingAddress: true,
+      },
+    });
+
+    if (!order) {
+      throw new AppError(404, 'Sales order not found');
+    }
+
+    res.json(order);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── POST /sales-orders ─────────────────────────────────────────────
+salesOrdersRouter.post('/', canWrite, async (req: AuthRequest, res, next) => {
+  try {
+    const input = createSalesOrderSchema.parse(req.body);
+    const tenantId = req.user!.tenantId;
+    const auditContext = getRequestAuditContext(req);
+
+    // Verify customer exists and belongs to tenant
+    const customer = await db.query.customers.findFirst({
+      where: and(eq(customers.id, input.customerId), eq(customers.tenantId, tenantId)),
+    });
+    if (!customer) {
+      throw new AppError(404, 'Customer not found');
+    }
+
+    const created = await db.transaction(async (tx) => {
+      const soNumber = await getNextSONumber(tenantId, tx);
+
+      // Build lines with computed totals
+      const lineData = input.lines.map((line, idx) => ({
+        tenantId,
+        partId: line.partId,
+        lineNumber: idx + 1,
+        quantityOrdered: line.quantityOrdered,
+        unitPrice: String(line.unitPrice),
+        discountPercent: String(line.discountPercent ?? 0),
+        lineTotal: computeLineTotal(line.quantityOrdered, line.unitPrice, line.discountPercent ?? 0),
+        notes: line.notes,
+      }));
+
+      const { subtotal, totalAmount } = computeOrderTotals(lineData);
+
+      const [order] = await tx
+        .insert(salesOrders)
+        .values({
+          tenantId,
+          soNumber,
+          customerId: input.customerId,
+          facilityId: input.facilityId,
+          status: 'draft',
+          orderDate: input.orderDate ? new Date(input.orderDate) : new Date(),
+          requestedShipDate: input.requestedShipDate ? new Date(input.requestedShipDate) : undefined,
+          shippingAddressId: input.shippingAddressId,
+          billingAddressId: input.billingAddressId,
+          paymentTerms: input.paymentTerms,
+          shippingMethod: input.shippingMethod,
+          notes: input.notes,
+          internalNotes: input.internalNotes,
+          subtotal,
+          totalAmount,
+          createdByUserId: req.user!.sub,
+        })
+        .returning();
+
+      // Insert lines
+      const insertedLines = [];
+      for (const line of lineData) {
+        const [inserted] = await tx
+          .insert(salesOrderLines)
+          .values({ ...line, salesOrderId: order.id })
+          .returning();
+        insertedLines.push(inserted);
+      }
+
+      await writeAuditEntry(tx, {
+        tenantId,
+        userId: auditContext.userId,
+        action: 'sales_order.created',
+        entityType: 'sales_order',
+        entityId: order.id,
+        newState: {
+          soNumber: order.soNumber,
+          customerId: order.customerId,
+          status: order.status,
+          lineCount: insertedLines.length,
+          totalAmount,
+        },
+        metadata: { source: 'sales-orders.create', customerName: customer.name },
+        ipAddress: auditContext.ipAddress,
+        userAgent: auditContext.userAgent,
+      });
+
+      return { ...order, lines: insertedLines };
+    });
+
+    res.status(201).json(created);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ error: 'Validation error', details: err.errors });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── PATCH /sales-orders/:id ────────────────────────────────────────
+salesOrdersRouter.patch('/:id', canWrite, async (req: AuthRequest, res, next) => {
+  try {
+    const input = updateSalesOrderSchema.parse(req.body);
+    const auditContext = getRequestAuditContext(req);
+    const existing = await findOrderOrThrow(req.params.id as string, req);
+
+    // Only draft/confirmed orders can be edited
+    if (!['draft', 'confirmed'].includes(existing.status)) {
+      throw new AppError(409, `Cannot edit sales order in "${existing.status}" status`);
+    }
+
+    const changedFields = Object.keys(input) as (keyof typeof input)[];
+    const previousState: Record<string, unknown> = {};
+    const newState: Record<string, unknown> = {};
+    for (const key of changedFields) {
+      previousState[key] = (existing as Record<string, unknown>)[key];
+      newState[key] = input[key];
+    }
+
+    // Convert date strings to Date objects for DB
+    const dbValues: Record<string, unknown> = { ...input, updatedAt: new Date() };
+    if (input.requestedShipDate) dbValues.requestedShipDate = new Date(input.requestedShipDate);
+    if (input.promisedShipDate) dbValues.promisedShipDate = new Date(input.promisedShipDate);
+
+    const updated = await db.transaction(async (tx) => {
+      const [row] = await tx
+        .update(salesOrders)
+        .set(dbValues)
+        .where(and(
+          eq(salesOrders.id, req.params.id as string),
+          eq(salesOrders.tenantId, req.user!.tenantId),
+        ))
+        .returning();
+
+      await writeAuditEntry(tx, {
+        tenantId: req.user!.tenantId,
+        userId: auditContext.userId,
+        action: 'sales_order.updated',
+        entityType: 'sales_order',
+        entityId: row.id,
+        previousState,
+        newState,
+        metadata: { source: 'sales-orders.update', soNumber: row.soNumber },
+        ipAddress: auditContext.ipAddress,
+        userAgent: auditContext.userAgent,
+      });
+
+      return row;
+    });
+
+    res.json(updated);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ error: 'Validation error', details: err.errors });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ═════════════════════════════════════════════════════════════════════
+//  Status Transitions
+// ═════════════════════════════════════════════════════════════════════
+
+// ─── POST /sales-orders/:id/submit ──────────────────────────────────
+// Transition: draft → confirmed
+salesOrdersRouter.post('/:id/submit', canWrite, async (req: AuthRequest, res, next) => {
+  try {
+    const existing = await findOrderOrThrow(req.params.id as string, req);
+    await transitionStatus(existing, 'confirmed', req, res);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ─── POST /sales-orders/:id/cancel ──────────────────────────────────
+salesOrdersRouter.post('/:id/cancel', canWrite, async (req: AuthRequest, res, next) => {
+  try {
+    const body = transitionStatusSchema.parse(req.body);
+    const existing = await findOrderOrThrow(req.params.id as string, req);
+    await transitionStatus(existing, 'cancelled', req, res, body.cancelReason);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ error: 'Validation error', details: err.errors });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── POST /sales-orders/:id/approve ─────────────────────────────────
+// Approve a confirmed SO → processing with inventory reservation, demand signals, and kanban triggers
+const canApprove = requireRole('ecommerce_director');
+
+salesOrdersRouter.post('/:id/approve', canApprove, async (req: AuthRequest, res, next) => {
+  try {
+    const existing = await findOrderOrThrow(req.params.id as string, req);
+    const auditContext = getRequestAuditContext(req);
+
+    const result = await approveSalesOrder(
+      existing.id as string,
+      req.user!.tenantId,
+      req.user!.sub,
+      existing.facilityId as string,
+      auditContext,
+    );
+
+    res.json(result);
+  } catch (err) {
+    if (err && typeof err === 'object' && 'statusCode' in err) {
+      const e = err as { statusCode: number; message: string };
+      res.status(e.statusCode).json({ error: e.message });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── POST /sales-orders/:id/cancel-with-release ────────────────────
+// Cancel a SO and release any reserved inventory + record reversal demand signals
+salesOrdersRouter.post('/:id/cancel-with-release', canWrite, async (req: AuthRequest, res, next) => {
+  try {
+    const body = transitionStatusSchema.parse(req.body);
+    const existing = await findOrderOrThrow(req.params.id as string, req);
+    const auditContext = getRequestAuditContext(req);
+
+    const result = await cancelSalesOrder(
+      existing.id as string,
+      req.user!.tenantId,
+      req.user!.sub,
+      body.cancelReason,
+      auditContext,
+    );
+
+    res.json(result);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ error: 'Validation error', details: err.errors });
+      return;
+    }
+    if (err && typeof err === 'object' && 'statusCode' in err) {
+      const e = err as { statusCode: number; message: string };
+      res.status(e.statusCode).json({ error: e.message });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── POST /sales-orders/:id/transition ──────────────────────────────
+// Generic transition endpoint for all valid transitions
+salesOrdersRouter.post('/:id/transition', canWrite, async (req: AuthRequest, res, next) => {
+  try {
+    const body = z.object({
+      status: z.enum(soStatusValues),
+      cancelReason: z.string().optional(),
+    }).parse(req.body);
+
+    const existing = await findOrderOrThrow(req.params.id as string, req);
+    await transitionStatus(existing, body.status, req, res, body.cancelReason);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ error: 'Validation error', details: err.errors });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── POST /sales-orders/:id/convert-quote ───────────────────────────
+// Converts a draft (quote) to confirmed (order)
+salesOrdersRouter.post('/:id/convert-quote', canWrite, async (req: AuthRequest, res, next) => {
+  try {
+    const existing = await findOrderOrThrow(req.params.id as string, req);
+    if (existing.status !== 'draft') {
+      throw new AppError(409, 'Only draft orders (quotes) can be converted');
+    }
+    await transitionStatus(existing, 'confirmed', req, res);
+  } catch (err) {
+    next(err);
+  }
+});
+
+async function transitionStatus(
+  existing: Record<string, unknown>,
+  targetStatus: SOStatus,
+  req: AuthRequest,
+  res: express.Response,
+  cancelReason?: string
+) {
+  const currentStatus = existing.status as SOStatus;
+  const allowed = SO_VALID_TRANSITIONS[currentStatus];
+
+  if (!allowed.includes(targetStatus)) {
+    throw new AppError(
+      409,
+      `Cannot transition from "${currentStatus}" to "${targetStatus}". Allowed: ${allowed.join(', ') || 'none'}`
+    );
+  }
+
+  const auditContext = getRequestAuditContext(req);
+  const updateData: Record<string, unknown> = {
+    status: targetStatus,
+    updatedAt: new Date(),
+  };
+  if (targetStatus === 'cancelled') {
+    updateData.cancelledAt = new Date();
+    if (cancelReason) updateData.cancelReason = cancelReason;
+  }
+  if (targetStatus === 'shipped' && !existing.actualShipDate) {
+    updateData.actualShipDate = new Date();
+  }
+
+  const updated = await db.transaction(async (tx) => {
+    const [row] = await tx
+      .update(salesOrders)
+      .set(updateData)
+      .where(and(
+        eq(salesOrders.id, existing.id as string),
+        eq(salesOrders.tenantId, req.user!.tenantId),
+      ))
+      .returning();
+
+    await writeAuditEntry(tx, {
+      tenantId: req.user!.tenantId,
+      userId: auditContext.userId,
+      action: 'sales_order.status_changed',
+      entityType: 'sales_order',
+      entityId: row.id,
+      previousState: { status: currentStatus },
+      newState: { status: targetStatus },
+      metadata: {
+        source: 'sales-orders.transition',
+        soNumber: row.soNumber,
+        ...(cancelReason ? { cancelReason } : {}),
+      },
+      ipAddress: auditContext.ipAddress,
+      userAgent: auditContext.userAgent,
+    });
+
+    return row;
+  });
+
+  res.json(updated);
+}
+
+// Need express type for transitionStatus response parameter
+import type express from 'express';
+
+// ═════════════════════════════════════════════════════════════════════
+//  Sales Order Lines
+// ═════════════════════════════════════════════════════════════════════
+
+// ─── POST /sales-orders/:id/lines ───────────────────────────────────
+salesOrdersRouter.post('/:id/lines', canWrite, async (req: AuthRequest, res, next) => {
+  try {
+    const input = addLineSchema.parse(req.body);
+    const auditContext = getRequestAuditContext(req);
+    const order = await findOrderOrThrow(req.params.id as string, req);
+
+    if (!['draft', 'confirmed'].includes(order.status as string)) {
+      throw new AppError(409, `Cannot add lines to order in "${order.status}" status`);
+    }
+
+    const created = await db.transaction(async (tx) => {
+      // Get next line number
+      const existingLines = await tx
+        .select({ lineNumber: salesOrderLines.lineNumber })
+        .from(salesOrderLines)
+        .where(eq(salesOrderLines.salesOrderId, order.id as string))
+        .orderBy(desc(salesOrderLines.lineNumber))
+        .limit(1);
+
+      const nextLineNumber = existingLines.length > 0 ? (existingLines[0].lineNumber + 1) : 1;
+      const lineTotal = computeLineTotal(input.quantityOrdered, input.unitPrice, input.discountPercent ?? 0);
+
+      const [line] = await tx
+        .insert(salesOrderLines)
+        .values({
+          tenantId: req.user!.tenantId,
+          salesOrderId: order.id as string,
+          partId: input.partId,
+          lineNumber: nextLineNumber,
+          quantityOrdered: input.quantityOrdered,
+          unitPrice: String(input.unitPrice),
+          discountPercent: String(input.discountPercent ?? 0),
+          lineTotal,
+          notes: input.notes,
+        })
+        .returning();
+
+      // Recalculate order totals
+      const allLines = await tx
+        .select({ lineTotal: salesOrderLines.lineTotal })
+        .from(salesOrderLines)
+        .where(eq(salesOrderLines.salesOrderId, order.id as string));
+
+      const { subtotal, totalAmount } = computeOrderTotals(
+        allLines.map(l => ({ lineTotal: l.lineTotal }))
+      );
+
+      await tx
+        .update(salesOrders)
+        .set({ subtotal, totalAmount, updatedAt: new Date() })
+        .where(eq(salesOrders.id, order.id as string));
+
+      await writeAuditEntry(tx, {
+        tenantId: req.user!.tenantId,
+        userId: auditContext.userId,
+        action: 'sales_order_line.added',
+        entityType: 'sales_order_line',
+        entityId: line.id,
+        newState: {
+          salesOrderId: line.salesOrderId,
+          partId: line.partId,
+          lineNumber: line.lineNumber,
+          quantityOrdered: line.quantityOrdered,
+          unitPrice: line.unitPrice,
+          lineTotal: line.lineTotal,
+        },
+        metadata: { source: 'sales-orders.lines.add', soNumber: order.soNumber },
+        ipAddress: auditContext.ipAddress,
+        userAgent: auditContext.userAgent,
+      });
+
+      return line;
+    });
+
+    res.status(201).json(created);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ error: 'Validation error', details: err.errors });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── PATCH /sales-orders/:id/lines/:lineId ──────────────────────────
+salesOrdersRouter.patch('/:id/lines/:lineId', canWrite, async (req: AuthRequest, res, next) => {
+  try {
+    const input = updateLineSchema.parse(req.body);
+    const auditContext = getRequestAuditContext(req);
+    const order = await findOrderOrThrow(req.params.id as string, req);
+
+    if (!['draft', 'confirmed'].includes(order.status as string)) {
+      throw new AppError(409, `Cannot update lines on order in "${order.status}" status`);
+    }
+
+    const existingLine = await db.query.salesOrderLines.findFirst({
+      where: and(
+        eq(salesOrderLines.id, req.params.lineId as string),
+        eq(salesOrderLines.salesOrderId, req.params.id as string),
+        eq(salesOrderLines.tenantId, req.user!.tenantId),
+      ),
+    });
+    if (!existingLine) {
+      throw new AppError(404, 'Sales order line not found');
+    }
+
+    const changedFields = Object.keys(input) as (keyof typeof input)[];
+    const previousState: Record<string, unknown> = {};
+    const newState: Record<string, unknown> = {};
+    for (const key of changedFields) {
+      previousState[key] = (existingLine as Record<string, unknown>)[key];
+      newState[key] = input[key];
+    }
+
+    const updated = await db.transaction(async (tx) => {
+      // Compute new lineTotal if qty or price changed
+      const qty = input.quantityOrdered ?? existingLine.quantityOrdered;
+      const price = input.unitPrice ?? parseFloat(existingLine.unitPrice);
+      const discount = input.discountPercent ?? parseFloat(existingLine.discountPercent ?? '0');
+      const lineTotal = computeLineTotal(qty, price, discount);
+
+      const setValues: Record<string, unknown> = { ...input, lineTotal, updatedAt: new Date() };
+      if (input.unitPrice !== undefined) setValues.unitPrice = String(input.unitPrice);
+      if (input.discountPercent !== undefined) setValues.discountPercent = String(input.discountPercent);
+
+      const [row] = await tx
+        .update(salesOrderLines)
+        .set(setValues)
+        .where(and(
+          eq(salesOrderLines.id, req.params.lineId as string),
+          eq(salesOrderLines.tenantId, req.user!.tenantId),
+        ))
+        .returning();
+
+      // Recalculate order totals
+      const allLines = await tx
+        .select({ lineTotal: salesOrderLines.lineTotal })
+        .from(salesOrderLines)
+        .where(eq(salesOrderLines.salesOrderId, req.params.id as string));
+
+      const { subtotal, totalAmount } = computeOrderTotals(
+        allLines.map(l => ({ lineTotal: l.lineTotal }))
+      );
+
+      await tx
+        .update(salesOrders)
+        .set({ subtotal, totalAmount, updatedAt: new Date() })
+        .where(eq(salesOrders.id, req.params.id as string));
+
+      await writeAuditEntry(tx, {
+        tenantId: req.user!.tenantId,
+        userId: auditContext.userId,
+        action: 'sales_order_line.updated',
+        entityType: 'sales_order_line',
+        entityId: row.id,
+        previousState,
+        newState: { ...newState, lineTotal },
+        metadata: { source: 'sales-orders.lines.update', soNumber: order.soNumber },
+        ipAddress: auditContext.ipAddress,
+        userAgent: auditContext.userAgent,
+      });
+
+      return row;
+    });
+
+    res.json(updated);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      res.status(400).json({ error: 'Validation error', details: err.errors });
+      return;
+    }
+    next(err);
+  }
+});
+
+// ─── DELETE /sales-orders/:id/lines/:lineId ─────────────────────────
+salesOrdersRouter.delete('/:id/lines/:lineId', canWrite, async (req: AuthRequest, res, next) => {
+  try {
+    const auditContext = getRequestAuditContext(req);
+    const order = await findOrderOrThrow(req.params.id as string, req);
+
+    if (!['draft', 'confirmed'].includes(order.status as string)) {
+      throw new AppError(409, `Cannot delete lines from order in "${order.status}" status`);
+    }
+
+    const existingLine = await db.query.salesOrderLines.findFirst({
+      where: and(
+        eq(salesOrderLines.id, req.params.lineId as string),
+        eq(salesOrderLines.salesOrderId, req.params.id as string),
+        eq(salesOrderLines.tenantId, req.user!.tenantId),
+      ),
+    });
+    if (!existingLine) {
+      throw new AppError(404, 'Sales order line not found');
+    }
+
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(salesOrderLines)
+        .where(and(
+          eq(salesOrderLines.id, req.params.lineId as string),
+          eq(salesOrderLines.tenantId, req.user!.tenantId),
+        ));
+
+      // Recalculate order totals
+      const allLines = await tx
+        .select({ lineTotal: salesOrderLines.lineTotal })
+        .from(salesOrderLines)
+        .where(eq(salesOrderLines.salesOrderId, req.params.id as string));
+
+      const { subtotal, totalAmount } = computeOrderTotals(
+        allLines.map(l => ({ lineTotal: l.lineTotal }))
+      );
+
+      await tx
+        .update(salesOrders)
+        .set({ subtotal, totalAmount, updatedAt: new Date() })
+        .where(eq(salesOrders.id, req.params.id as string));
+
+      await writeAuditEntry(tx, {
+        tenantId: req.user!.tenantId,
+        userId: auditContext.userId,
+        action: 'sales_order_line.deleted',
+        entityType: 'sales_order_line',
+        entityId: existingLine.id,
+        previousState: {
+          salesOrderId: existingLine.salesOrderId,
+          partId: existingLine.partId,
+          lineNumber: existingLine.lineNumber,
+          quantityOrdered: existingLine.quantityOrdered,
+          unitPrice: existingLine.unitPrice,
+          lineTotal: existingLine.lineTotal,
+        },
+        metadata: { source: 'sales-orders.lines.delete', soNumber: order.soNumber },
+        ipAddress: auditContext.ipAddress,
+        userAgent: auditContext.userAgent,
+      });
+    });
+
+    res.json({ deleted: true });
+  } catch (err) {
+    next(err);
+  }
+});

--- a/services/orders/src/services/sales-order-approval.service.test.ts
+++ b/services/orders/src/services/sales-order-approval.service.test.ts
@@ -1,0 +1,723 @@
+/**
+ * Unit tests for Sales Order Approval Service (Ticket #194)
+ *
+ * Tests:
+ * - approveSalesOrder: confirmed → processing + reserve + demand signals
+ * - approveSalesOrder: partial inventory → correct allocation + shortfall signals
+ * - approveSalesOrder: zero available → shortfall only, no reservation
+ * - approveSalesOrder: rejects non-confirmed orders
+ * - approveSalesOrder: rejects orders with no lines
+ * - cancelSalesOrder: release reserved inventory + reversal demand signals
+ * - cancelSalesOrder: rejects terminal statuses
+ * - cancelSalesOrder: handles lines with no allocations
+ * - evaluateKanbanTrigger: triggers card when available <= minQuantity
+ * - evaluateKanbanTrigger: skips when active cards exist
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── Hoisted test state ─────────────────────────────────────────────
+const testState = vi.hoisted(() => ({
+  auditEntries: [] as Array<Record<string, unknown>>,
+  insertedDemandSignals: [] as Array<Record<string, unknown>>,
+  inventoryUpdates: [] as Array<Record<string, unknown>>,
+  cardUpdates: [] as Array<Record<string, unknown>>,
+  lineUpdates: [] as Array<Record<string, unknown>>,
+  orderUpdates: [] as Array<Record<string, unknown>>,
+}));
+
+// ─── Hoisted constants ──────────────────────────────────────────────
+const IDS = vi.hoisted(() => ({
+  T: '00000000-0000-0000-0000-000000000001',
+  U: '00000000-0000-0000-0000-000000000011',
+  C: '00000000-0000-0000-0000-000000000021',
+  F: '00000000-0000-0000-0000-000000000031',
+  P1: '00000000-0000-0000-0000-000000000041',
+  P2: '00000000-0000-0000-0000-000000000042',
+  SO: '00000000-0000-0000-0000-000000000051',
+  L1: '00000000-0000-0000-0000-000000000061',
+  L2: '00000000-0000-0000-0000-000000000062',
+  INV1: '00000000-0000-0000-0000-000000000071',
+  INV2: '00000000-0000-0000-0000-000000000072',
+  LOOP1: '00000000-0000-0000-0000-000000000081',
+  CARD1: '00000000-0000-0000-0000-000000000091',
+}));
+
+// ─── Hoisted schema mock ────────────────────────────────────────────
+const schemaMock = vi.hoisted(() => ({
+  salesOrders: { id: 'salesOrders' },
+  salesOrderLines: { id: 'salesOrderLines' },
+  demandSignals: { id: 'demandSignals' },
+  inventoryLedger: {
+    id: 'inventoryLedger',
+    tenantId: 'tenantId',
+    facilityId: 'facilityId',
+    partId: 'partId',
+    qtyReserved: 'qtyReserved',
+  },
+  kanbanLoops: { id: 'kanbanLoops' },
+  kanbanCards: { id: 'kanbanCards' },
+}));
+
+// ─── Hoisted DB mock ────────────────────────────────────────────────
+const { dbMock, resetAllMocks } = vi.hoisted(() => {
+  // Queue-based mock: each query call shifts the next result off the queue
+  const queryQueue: Array<unknown> = [];
+
+  const chainable = () => {
+    const self: Record<string, unknown> = {};
+    const methods = ['from', 'where', 'limit', 'offset', 'orderBy', 'for'];
+    for (const m of methods) {
+      self[m] = vi.fn(() => self);
+    }
+    // Terminal: resolve by shifting from queue
+    self.then = (resolve: (v: unknown) => void) => resolve(queryQueue.shift() ?? []);
+    return self;
+  };
+
+  // Insert chain that captures inserts
+  const insertChain = () => {
+    const chain: Record<string, unknown> = {};
+    chain.values = vi.fn((val: unknown) => {
+      // Track inserted demand signals
+      if (val && typeof val === 'object' && 'signalType' in (val as Record<string, unknown>)) {
+        testState.insertedDemandSignals.push(val as Record<string, unknown>);
+      }
+      return chain;
+    });
+    chain.returning = vi.fn(() => chain);
+    chain.onConflictDoNothing = vi.fn(() => chain);
+    chain.then = (resolve: (v: unknown) => void) => resolve(undefined);
+    return chain;
+  };
+
+  // Update chain that captures updates
+  const updateChain = (table: unknown) => {
+    const chain: Record<string, unknown> = {};
+    chain.set = vi.fn((val: unknown) => {
+      if (table === schemaMock.inventoryLedger) testState.inventoryUpdates.push(val as Record<string, unknown>);
+      if (table === schemaMock.kanbanCards) testState.cardUpdates.push(val as Record<string, unknown>);
+      if (table === schemaMock.salesOrderLines) testState.lineUpdates.push(val as Record<string, unknown>);
+      if (table === schemaMock.salesOrders) testState.orderUpdates.push(val as Record<string, unknown>);
+      return chain;
+    });
+    chain.where = vi.fn(() => chain);
+    chain.returning = vi.fn(() => chain);
+    chain.then = (resolve: (v: unknown) => void) => {
+      // For salesOrders update().set().where().returning(), resolve with the updated order
+      if (table === schemaMock.salesOrders) {
+        resolve([{
+          ...defaultOrder(),
+          status: 'processing',
+        }]);
+      } else {
+        resolve(undefined);
+      }
+    };
+    return chain;
+  };
+
+  function defaultOrder() {
+    return {
+      id: IDS.SO,
+      tenantId: IDS.T,
+      soNumber: 'SO-20260215-0001',
+      customerId: IDS.C,
+      facilityId: IDS.F,
+      status: 'confirmed',
+      subtotal: '100.00',
+      totalAmount: '100.00',
+      cancelledAt: null,
+      cancelReason: null,
+    };
+  }
+
+  const tx = {
+    select: vi.fn(() => chainable()),
+    insert: vi.fn(() => insertChain()),
+    update: vi.fn((table: unknown) => updateChain(table)),
+    delete: vi.fn(),
+    execute: vi.fn(),
+  };
+
+  const dbMock = {
+    query: {
+      salesOrders: { findFirst: vi.fn() },
+      salesOrderLines: { findFirst: vi.fn() },
+    },
+    select: vi.fn(() => chainable()),
+    insert: vi.fn(() => insertChain()),
+    update: vi.fn((table: unknown) => updateChain(table)),
+    transaction: vi.fn(async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx)),
+    execute: vi.fn(),
+  };
+
+  const resetAllMocks = () => {
+    queryQueue.length = 0;
+    testState.auditEntries.length = 0;
+    testState.insertedDemandSignals.length = 0;
+    testState.inventoryUpdates.length = 0;
+    testState.cardUpdates.length = 0;
+    testState.lineUpdates.length = 0;
+    testState.orderUpdates.length = 0;
+    dbMock.transaction.mockClear();
+    tx.select.mockClear();
+    tx.insert.mockClear();
+    tx.update.mockClear();
+  };
+
+  return { dbMock, tx, queryQueue, resetAllMocks, defaultOrder };
+});
+
+// ─── Hoisted audit mock ─────────────────────────────────────────────
+const mockWriteAuditEntry = vi.hoisted(() =>
+  vi.fn(async (_dbOrTx: unknown, entry: Record<string, unknown>) => {
+    testState.auditEntries.push(entry);
+    return { id: 'audit-' + testState.auditEntries.length, hashChain: 'mock', sequenceNumber: testState.auditEntries.length };
+  })
+);
+
+// ─── Module mocks ───────────────────────────────────────────────────
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn(() => ({})),
+  and: vi.fn(() => ({})),
+  or: vi.fn(() => ({})),
+  sql: Object.assign(vi.fn(() => ({})), { raw: vi.fn(() => ({})) }),
+  inArray: vi.fn(() => ({})),
+}));
+
+vi.mock('@arda/db', () => ({
+  db: dbMock,
+  schema: schemaMock,
+  writeAuditEntry: mockWriteAuditEntry,
+  writeAuditEntries: vi.fn(async () => []),
+}));
+
+vi.mock('@arda/config', () => ({
+  config: {},
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock('@arda/events', () => ({
+  getEventBus: () => ({ publish: vi.fn(async () => undefined), subscribe: vi.fn() }),
+}));
+
+vi.mock('./inventory-ledger.service.js', () => ({
+  adjustQuantity: vi.fn(async () => ({ previousValue: 0, newValue: 0, field: 'qtyReserved', adjustmentType: 'increment', quantity: 0 })),
+  upsertInventory: vi.fn(async () => ({})),
+}));
+
+// ─── Import under test ─────────────────────────────────────────────
+import { approveSalesOrder, cancelSalesOrder } from './sales-order-approval.service.js';
+
+// ─── Test helpers ───────────────────────────────────────────────────
+function makeOrder(overrides: Record<string, unknown> = {}) {
+  return {
+    id: IDS.SO,
+    tenantId: IDS.T,
+    soNumber: 'SO-20260215-0001',
+    customerId: IDS.C,
+    facilityId: IDS.F,
+    status: 'confirmed',
+    subtotal: '100.00',
+    totalAmount: '100.00',
+    cancelledAt: null,
+    cancelReason: null,
+    ...overrides,
+  };
+}
+
+function makeLine(overrides: Record<string, unknown> = {}) {
+  return {
+    id: IDS.L1,
+    tenantId: IDS.T,
+    salesOrderId: IDS.SO,
+    partId: IDS.P1,
+    lineNumber: 1,
+    quantityOrdered: 10,
+    quantityAllocated: 0,
+    quantityShipped: 0,
+    unitPrice: '10.0000',
+    discountPercent: '0',
+    lineTotal: '100.00',
+    ...overrides,
+  };
+}
+
+function makeLedger(overrides: Record<string, unknown> = {}) {
+  return {
+    id: IDS.INV1,
+    tenantId: IDS.T,
+    facilityId: IDS.F,
+    partId: IDS.P1,
+    qtyOnHand: 50,
+    qtyReserved: 0,
+    qtyInTransit: 0,
+    reorderPoint: 10,
+    reorderQty: 20,
+    ...overrides,
+  };
+}
+
+const auditCtx = { userId: IDS.U, ipAddress: '127.0.0.1', userAgent: 'test' };
+
+// ─── Setup ──────────────────────────────────────────────────────────
+// The queue-based approach: each call to tx.select()...for('update') or
+// tx.select()...where() shifts the next value from queryQueue.
+// We set up the queue before each test based on the expected DB calls.
+
+// Helper to set up the tx.select queue for approval flow:
+// 1. SELECT order FOR UPDATE → [order]
+// 2. SELECT lines → [line1, ...]
+// 3+. SELECT inventory FOR UPDATE → [ledger] (per line)
+function setupApprovalMocks(order: Record<string, unknown>, lines: Record<string, unknown>[], ledgers: Array<Record<string, unknown> | null>) {
+  const { queryQueue, tx } = vi.hoisted(() => ({ queryQueue: [] as unknown[], tx: {} as Record<string, unknown> }));
+
+  // We need to re-import from the hoisted mock since vi.hoisted returns fresh
+  // We'll use the dbMock.transaction mock to intercept calls instead
+
+  // Reset tx.select to use a call counter
+  let callIndex = 0;
+  const selectResults: unknown[][] = [
+    [order],           // 1st call: order FOR UPDATE
+    lines,             // 2nd call: lines
+  ];
+
+  // Add ledger rows for each line
+  for (const ledger of ledgers) {
+    selectResults.push(ledger ? [ledger] : []);
+  }
+
+  const { tx: txRef } = (() => {
+    // Access the hoisted tx via the dbMock.transaction mock
+    let capturedTx: Record<string, unknown> | null = null;
+    return { tx: capturedTx };
+  })();
+
+  // Instead of queue, override dbMock.transaction to use a custom tx
+  (dbMock.transaction as ReturnType<typeof vi.fn>).mockImplementation(async (cb: (t: unknown) => Promise<unknown>) => {
+    callIndex = 0;
+
+    const makeTxChain = () => {
+      const chain: Record<string, unknown> = {};
+      const methods = ['from', 'where', 'limit', 'offset', 'orderBy', 'for'];
+      for (const m of methods) {
+        chain[m] = vi.fn(() => chain);
+      }
+      const idx = callIndex++;
+      chain.then = (resolve: (v: unknown) => void) => resolve(selectResults[idx] ?? []);
+      return chain;
+    };
+
+    const txMock = {
+      select: vi.fn(() => makeTxChain()),
+      insert: vi.fn(() => {
+        const ic: Record<string, unknown> = {};
+        ic.values = vi.fn((val: unknown) => {
+          if (val && typeof val === 'object' && 'signalType' in (val as Record<string, unknown>)) {
+            testState.insertedDemandSignals.push(val as Record<string, unknown>);
+          }
+          return ic;
+        });
+        ic.returning = vi.fn(() => ic);
+        ic.onConflictDoNothing = vi.fn(() => ic);
+        ic.then = (resolve: (v: unknown) => void) => resolve(undefined);
+        return ic;
+      }),
+      update: vi.fn((table: unknown) => {
+        const uc: Record<string, unknown> = {};
+        uc.set = vi.fn((val: unknown) => {
+          if (table === schemaMock.inventoryLedger) testState.inventoryUpdates.push(val as Record<string, unknown>);
+          if (table === schemaMock.kanbanCards) testState.cardUpdates.push(val as Record<string, unknown>);
+          if (table === schemaMock.salesOrderLines) testState.lineUpdates.push(val as Record<string, unknown>);
+          if (table === schemaMock.salesOrders) testState.orderUpdates.push(val as Record<string, unknown>);
+          return uc;
+        });
+        uc.where = vi.fn(() => uc);
+        uc.returning = vi.fn(() => uc);
+        uc.then = (resolve: (v: unknown) => void) => {
+          if (table === schemaMock.salesOrders) {
+            resolve([{ ...order, status: 'processing' }]);
+          } else {
+            resolve(undefined);
+          }
+        };
+        return uc;
+      }),
+      execute: vi.fn(),
+    };
+
+    return cb(txMock);
+  });
+}
+
+function setupCancelMocks(order: Record<string, unknown>, lines: Record<string, unknown>[], ledgers: Array<Record<string, unknown> | null>) {
+  let callIndex = 0;
+  const selectResults: unknown[][] = [
+    [order],  // order FOR UPDATE
+    lines,    // lines
+  ];
+
+  // Add ledger rows for each line that has allocation
+  for (const ledger of ledgers) {
+    selectResults.push(ledger ? [ledger] : []);
+  }
+
+  (dbMock.transaction as ReturnType<typeof vi.fn>).mockImplementation(async (cb: (t: unknown) => Promise<unknown>) => {
+    callIndex = 0;
+
+    const makeTxChain = () => {
+      const chain: Record<string, unknown> = {};
+      for (const m of ['from', 'where', 'limit', 'offset', 'orderBy', 'for']) {
+        chain[m] = vi.fn(() => chain);
+      }
+      const idx = callIndex++;
+      chain.then = (resolve: (v: unknown) => void) => resolve(selectResults[idx] ?? []);
+      return chain;
+    };
+
+    const txMock = {
+      select: vi.fn(() => makeTxChain()),
+      insert: vi.fn(() => {
+        const ic: Record<string, unknown> = {};
+        ic.values = vi.fn((val: unknown) => {
+          if (val && typeof val === 'object' && 'signalType' in (val as Record<string, unknown>)) {
+            testState.insertedDemandSignals.push(val as Record<string, unknown>);
+          }
+          return ic;
+        });
+        ic.returning = vi.fn(() => ic);
+        ic.onConflictDoNothing = vi.fn(() => ic);
+        ic.then = (resolve: (v: unknown) => void) => resolve(undefined);
+        return ic;
+      }),
+      update: vi.fn((table: unknown) => {
+        const uc: Record<string, unknown> = {};
+        uc.set = vi.fn((val: unknown) => {
+          if (table === schemaMock.inventoryLedger) testState.inventoryUpdates.push(val as Record<string, unknown>);
+          if (table === schemaMock.salesOrderLines) testState.lineUpdates.push(val as Record<string, unknown>);
+          if (table === schemaMock.salesOrders) testState.orderUpdates.push(val as Record<string, unknown>);
+          return uc;
+        });
+        uc.where = vi.fn(() => uc);
+        uc.returning = vi.fn(() => uc);
+        uc.then = (resolve: (v: unknown) => void) => resolve(undefined);
+        return uc;
+      }),
+      execute: vi.fn(),
+    };
+
+    return cb(txMock as unknown as Parameters<Parameters<typeof dbMock.transaction>[0]>[0]);
+  });
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+describe('Sales Order Approval Service', () => {
+  beforeEach(() => {
+    resetAllMocks();
+  });
+
+  // ═══════════════════════════════════════════════════════════════════
+  //  approveSalesOrder
+  // ═══════════════════════════════════════════════════════════════════
+
+  describe('approveSalesOrder', () => {
+    it('should transition confirmed → processing and reserve full inventory', async () => {
+      const order = makeOrder();
+      const line = makeLine();
+      const ledger = makeLedger({ qtyOnHand: 50, qtyReserved: 0 });
+
+      setupApprovalMocks(order, [line], [ledger]);
+
+      const result = await approveSalesOrder(IDS.SO, IDS.T, IDS.U, IDS.F, auditCtx);
+
+      expect(result.newStatus).toBe('processing');
+      expect(result.previousStatus).toBe('confirmed');
+      expect(result.reservations).toHaveLength(1);
+      expect(result.reservations[0].quantityReserved).toBe(10);
+      expect(result.reservations[0].shortfall).toBe(0);
+      expect(result.demandSignalsCreated).toBe(1); // 1 sales_order signal, 0 shortfall signals
+    });
+
+    it('should handle partial inventory — reserve available, record shortfall', async () => {
+      const order = makeOrder();
+      const line = makeLine({ quantityOrdered: 20 });
+      const ledger = makeLedger({ qtyOnHand: 8, qtyReserved: 0 }); // Only 8 available
+
+      setupApprovalMocks(order, [line], [ledger]);
+
+      const result = await approveSalesOrder(IDS.SO, IDS.T, IDS.U, IDS.F, auditCtx);
+
+      expect(result.reservations[0].quantityReserved).toBe(8);
+      expect(result.reservations[0].shortfall).toBe(12);
+      expect(result.demandSignalsCreated).toBe(2); // 1 sales_order + 1 shortfall reorder_point
+    });
+
+    it('should handle zero available inventory', async () => {
+      const order = makeOrder();
+      const line = makeLine({ quantityOrdered: 10 });
+      const ledger = makeLedger({ qtyOnHand: 0, qtyReserved: 0 });
+
+      setupApprovalMocks(order, [line], [ledger]);
+
+      const result = await approveSalesOrder(IDS.SO, IDS.T, IDS.U, IDS.F, auditCtx);
+
+      expect(result.reservations[0].quantityReserved).toBe(0);
+      expect(result.reservations[0].shortfall).toBe(10);
+      expect(result.demandSignalsCreated).toBe(2); // 1 sales_order + 1 shortfall
+    });
+
+    it('should handle multiple lines with different parts', async () => {
+      const order = makeOrder();
+      const line1 = makeLine({ id: IDS.L1, partId: IDS.P1, quantityOrdered: 5 });
+      const line2 = makeLine({ id: IDS.L2, partId: IDS.P2, lineNumber: 2, quantityOrdered: 10 });
+      const ledger1 = makeLedger({ id: IDS.INV1, partId: IDS.P1, qtyOnHand: 5, qtyReserved: 0 });
+      const ledger2 = makeLedger({ id: IDS.INV2, partId: IDS.P2, qtyOnHand: 3, qtyReserved: 0 });
+
+      setupApprovalMocks(order, [line1, line2], [ledger1, ledger2]);
+
+      const result = await approveSalesOrder(IDS.SO, IDS.T, IDS.U, IDS.F, auditCtx);
+
+      expect(result.reservations).toHaveLength(2);
+      expect(result.reservations[0].quantityReserved).toBe(5);
+      expect(result.reservations[0].shortfall).toBe(0);
+      expect(result.reservations[1].quantityReserved).toBe(3);
+      expect(result.reservations[1].shortfall).toBe(7);
+    });
+
+    it('should reject non-confirmed orders (draft)', async () => {
+      const order = makeOrder({ status: 'draft' });
+
+      setupApprovalMocks(order, [], []);
+
+      await expect(
+        approveSalesOrder(IDS.SO, IDS.T, IDS.U, IDS.F, auditCtx),
+      ).rejects.toThrow('Cannot approve order in "draft" status');
+    });
+
+    it('should reject non-confirmed orders (processing)', async () => {
+      const order = makeOrder({ status: 'processing' });
+
+      setupApprovalMocks(order, [], []);
+
+      await expect(
+        approveSalesOrder(IDS.SO, IDS.T, IDS.U, IDS.F, auditCtx),
+      ).rejects.toThrow('Cannot approve order in "processing" status');
+    });
+
+    it('should reject order not found', async () => {
+      // Empty result for order query
+      (dbMock.transaction as ReturnType<typeof vi.fn>).mockImplementation(async (cb: (t: unknown) => Promise<unknown>) => {
+        let callIdx = 0;
+        const makeTxChain = () => {
+          const chain: Record<string, unknown> = {};
+          for (const m of ['from', 'where', 'limit', 'offset', 'orderBy', 'for']) {
+            chain[m] = vi.fn(() => chain);
+          }
+          const idx = callIdx++;
+          chain.then = (resolve: (v: unknown) => void) => resolve(idx === 0 ? [] : []); // empty order
+          return chain;
+        };
+        return cb({ select: vi.fn(() => makeTxChain()), insert: vi.fn(), update: vi.fn(), execute: vi.fn() } as never);
+      });
+
+      await expect(
+        approveSalesOrder(IDS.SO, IDS.T, IDS.U, IDS.F, auditCtx),
+      ).rejects.toThrow('Sales order not found');
+    });
+
+    it('should reject order with no lines', async () => {
+      const order = makeOrder();
+
+      setupApprovalMocks(order, [], []);
+
+      await expect(
+        approveSalesOrder(IDS.SO, IDS.T, IDS.U, IDS.F, auditCtx),
+      ).rejects.toThrow('Sales order has no lines');
+    });
+
+    it('should write audit entry with approval details', async () => {
+      const order = makeOrder();
+      const line = makeLine();
+      const ledger = makeLedger({ qtyOnHand: 50, qtyReserved: 0 });
+
+      setupApprovalMocks(order, [line], [ledger]);
+
+      await approveSalesOrder(IDS.SO, IDS.T, IDS.U, IDS.F, auditCtx);
+
+      expect(testState.auditEntries).toHaveLength(1);
+      expect(testState.auditEntries[0].action).toBe('sales_order.approved');
+      expect(testState.auditEntries[0].entityType).toBe('sales_order');
+      expect(testState.auditEntries[0].entityId).toBe(IDS.SO);
+    });
+
+    it('should create demand signals for each line', async () => {
+      const order = makeOrder();
+      const line = makeLine();
+      const ledger = makeLedger({ qtyOnHand: 50, qtyReserved: 0 });
+
+      setupApprovalMocks(order, [line], [ledger]);
+
+      await approveSalesOrder(IDS.SO, IDS.T, IDS.U, IDS.F, auditCtx);
+
+      const salesSignals = testState.insertedDemandSignals.filter(
+        (s) => s.signalType === 'sales_order',
+      );
+      expect(salesSignals).toHaveLength(1);
+      expect(salesSignals[0].partId).toBe(IDS.P1);
+      expect(salesSignals[0].quantityDemanded).toBe(10);
+    });
+
+    it('should create stockout signals for shortfall lines', async () => {
+      const order = makeOrder();
+      const line = makeLine({ quantityOrdered: 20 });
+      const ledger = makeLedger({ qtyOnHand: 5, qtyReserved: 0 });
+
+      setupApprovalMocks(order, [line], [ledger]);
+
+      await approveSalesOrder(IDS.SO, IDS.T, IDS.U, IDS.F, auditCtx);
+
+      const stockoutSignals = testState.insertedDemandSignals.filter(
+        (s) => s.signalType === 'reorder_point',
+      );
+      expect(stockoutSignals).toHaveLength(1);
+      expect(stockoutSignals[0].quantityDemanded).toBe(15); // 20 - 5
+      expect((stockoutSignals[0].metadata as Record<string, unknown>).type).toBe('stockout_inquiry');
+    });
+
+    it('should account for existing allocations when computing reservable', async () => {
+      const order = makeOrder();
+      // Line already has 5 allocated
+      const line = makeLine({ quantityOrdered: 10, quantityAllocated: 5 });
+      const ledger = makeLedger({ qtyOnHand: 50, qtyReserved: 5 });
+
+      setupApprovalMocks(order, [line], [ledger]);
+
+      const result = await approveSalesOrder(IDS.SO, IDS.T, IDS.U, IDS.F, auditCtx);
+
+      // available = 50 - 5 = 45, needed = 10 - 5 = 5, reservable = min(45, 5) = 5
+      expect(result.reservations[0].quantityReserved).toBe(5);
+      expect(result.reservations[0].shortfall).toBe(0);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════
+  //  cancelSalesOrder
+  // ═══════════════════════════════════════════════════════════════════
+
+  describe('cancelSalesOrder', () => {
+    it('should cancel order and release reserved inventory', async () => {
+      const order = makeOrder({ status: 'processing' });
+      const line = makeLine({ quantityAllocated: 10 });
+      const ledger = makeLedger({ qtyOnHand: 50, qtyReserved: 10 });
+
+      setupCancelMocks(order, [line], [ledger]);
+
+      const result = await cancelSalesOrder(IDS.SO, IDS.T, IDS.U, 'Customer request', auditCtx);
+
+      expect(result.previousStatus).toBe('processing');
+      expect(result.inventoryReleased).toBe(10);
+      expect(result.demandSignalsCancelled).toBe(1);
+    });
+
+    it('should handle lines with no allocations (draft cancel)', async () => {
+      const order = makeOrder({ status: 'draft' });
+      const line = makeLine({ quantityAllocated: 0 });
+
+      setupCancelMocks(order, [line], []);
+
+      const result = await cancelSalesOrder(IDS.SO, IDS.T, IDS.U, undefined, auditCtx);
+
+      expect(result.inventoryReleased).toBe(0);
+      expect(result.demandSignalsCancelled).toBe(1); // Still records reversal signal
+    });
+
+    it('should reject cancellation of terminal statuses', async () => {
+      const order = makeOrder({ status: 'cancelled' });
+
+      setupCancelMocks(order, [], []);
+
+      await expect(
+        cancelSalesOrder(IDS.SO, IDS.T, IDS.U, undefined, auditCtx),
+      ).rejects.toThrow('Cannot cancel order in "cancelled" status');
+    });
+
+    it('should reject cancellation of closed orders', async () => {
+      const order = makeOrder({ status: 'closed' });
+
+      setupCancelMocks(order, [], []);
+
+      await expect(
+        cancelSalesOrder(IDS.SO, IDS.T, IDS.U, undefined, auditCtx),
+      ).rejects.toThrow('Cannot cancel order in "closed" status');
+    });
+
+    it('should write audit entry with cancellation details', async () => {
+      const order = makeOrder({ status: 'confirmed' });
+      const line = makeLine({ quantityAllocated: 0 });
+
+      setupCancelMocks(order, [line], []);
+
+      await cancelSalesOrder(IDS.SO, IDS.T, IDS.U, 'Out of stock', auditCtx);
+
+      expect(testState.auditEntries).toHaveLength(1);
+      expect(testState.auditEntries[0].action).toBe('sales_order.cancelled');
+      expect((testState.auditEntries[0].newState as Record<string, unknown>).cancelReason).toBe('Out of stock');
+    });
+
+    it('should record reversal demand signals for each line', async () => {
+      const order = makeOrder({ status: 'processing' });
+      const line1 = makeLine({ id: IDS.L1, partId: IDS.P1, quantityOrdered: 10, quantityAllocated: 10 });
+      const line2 = makeLine({ id: IDS.L2, partId: IDS.P2, lineNumber: 2, quantityOrdered: 5, quantityAllocated: 5 });
+      const ledger1 = makeLedger({ id: IDS.INV1, partId: IDS.P1, qtyReserved: 10 });
+      const ledger2 = makeLedger({ id: IDS.INV2, partId: IDS.P2, qtyReserved: 5 });
+
+      setupCancelMocks(order, [line1, line2], [ledger1, ledger2]);
+
+      const result = await cancelSalesOrder(IDS.SO, IDS.T, IDS.U, undefined, auditCtx);
+
+      expect(result.demandSignalsCancelled).toBe(2);
+      // Verify reversal signals have negative quantities
+      const reversals = testState.insertedDemandSignals.filter(
+        (s) => (s.metadata as Record<string, unknown>)?.type === 'cancellation',
+      );
+      expect(reversals).toHaveLength(2);
+      expect(reversals[0].quantityDemanded).toBe(-10);
+      expect(reversals[1].quantityDemanded).toBe(-5);
+    });
+
+    it('should release only up to available reserved quantity', async () => {
+      const order = makeOrder({ status: 'processing' });
+      // Line says 10 allocated but ledger only has 5 reserved (edge case)
+      const line = makeLine({ quantityAllocated: 10 });
+      const ledger = makeLedger({ qtyReserved: 5 });
+
+      setupCancelMocks(order, [line], [ledger]);
+
+      const result = await cancelSalesOrder(IDS.SO, IDS.T, IDS.U, undefined, auditCtx);
+
+      // Should release min(10, 5) = 5
+      expect(result.inventoryReleased).toBe(5);
+    });
+
+    it('should handle order not found', async () => {
+      (dbMock.transaction as ReturnType<typeof vi.fn>).mockImplementation(async (cb: (t: unknown) => Promise<unknown>) => {
+        let callIdx = 0;
+        const makeTxChain = () => {
+          const chain: Record<string, unknown> = {};
+          for (const m of ['from', 'where', 'limit', 'offset', 'orderBy', 'for']) {
+            chain[m] = vi.fn(() => chain);
+          }
+          const idx = callIdx++;
+          chain.then = (resolve: (v: unknown) => void) => resolve(idx === 0 ? [] : []);
+          return chain;
+        };
+        return cb({ select: vi.fn(() => makeTxChain()), insert: vi.fn(), update: vi.fn(), execute: vi.fn() } as never);
+      });
+
+      await expect(
+        cancelSalesOrder(IDS.SO, IDS.T, IDS.U, undefined, auditCtx),
+      ).rejects.toThrow('Sales order not found');
+    });
+  });
+});

--- a/services/orders/src/services/sales-order-approval.service.ts
+++ b/services/orders/src/services/sales-order-approval.service.ts
@@ -1,0 +1,632 @@
+/**
+ * Sales Order Approval Service
+ *
+ * Handles the operational side effects of approving or cancelling a sales order:
+ * - Inventory reservation (qtyReserved) per line
+ * - Demand signal recording
+ * - Kanban trigger evaluation
+ * - Cancellation release flow (reverse reservations + cancel demand signals)
+ */
+
+import { randomUUID } from 'node:crypto';
+import { db, schema, writeAuditEntry } from '@arda/db';
+import { eq, and, sql, inArray } from 'drizzle-orm';
+import {
+  getEventBus,
+  type EventMeta,
+  type SalesOrderApprovedEvent,
+  type SalesOrderCancelledEvent,
+  type DemandSignalCreatedEvent,
+  type OrderStatusChangedEvent,
+} from '@arda/events';
+import { createLogger } from '@arda/config';
+import type { AuditContext } from '@arda/auth-utils';
+
+import { adjustQuantity, upsertInventory } from './inventory-ledger.service.js';
+
+const log = createLogger('sales-order-approval');
+
+const {
+  salesOrders,
+  salesOrderLines,
+  demandSignals,
+  inventoryLedger,
+  kanbanLoops,
+  kanbanCards,
+} = schema;
+
+// ─── Types ────────────────────────────────────────────────────────────
+
+interface LineReservationResult {
+  lineId: string;
+  partId: string;
+  quantityOrdered: number;
+  quantityReserved: number;
+  shortfall: number;
+}
+
+export interface ApprovalResult {
+  orderId: string;
+  orderNumber: string;
+  previousStatus: string;
+  newStatus: string;
+  reservations: LineReservationResult[];
+  demandSignalsCreated: number;
+  kanbanCardsTriggered: number;
+}
+
+export interface CancellationResult {
+  orderId: string;
+  orderNumber: string;
+  previousStatus: string;
+  inventoryReleased: number;
+  demandSignalsCancelled: number;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function buildEventMeta(correlationId?: string): EventMeta {
+  return {
+    id: randomUUID(),
+    schemaVersion: 1,
+    source: 'orders.sales-order-approval',
+    correlationId,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// ─── Approve Sales Order ──────────────────────────────────────────────
+
+/**
+ * Approve a confirmed sales order:
+ * 1. Transition confirmed → processing
+ * 2. Reserve inventory per line (increment qtyReserved)
+ * 3. Record demand signals per line
+ * 4. Evaluate kanban triggers for affected parts
+ */
+export async function approveSalesOrder(
+  orderId: string,
+  tenantId: string,
+  userId: string,
+  facilityId: string,
+  auditContext: AuditContext,
+): Promise<ApprovalResult> {
+  // Phase 1: DB transaction — status change + demand signals + line allocation
+  const txResult = await db.transaction(async (tx) => {
+    // Fetch order with lines
+    const [order] = await tx
+      .select()
+      .from(salesOrders)
+      .where(and(eq(salesOrders.id, orderId), eq(salesOrders.tenantId, tenantId)))
+      .for('update');
+
+    if (!order) {
+      throw Object.assign(new Error('Sales order not found'), { statusCode: 404 });
+    }
+    if (order.status !== 'confirmed') {
+      throw Object.assign(
+        new Error(`Cannot approve order in "${order.status}" status — must be "confirmed"`),
+        { statusCode: 409 },
+      );
+    }
+
+    const lines = await tx
+      .select()
+      .from(salesOrderLines)
+      .where(and(
+        eq(salesOrderLines.salesOrderId, orderId),
+        eq(salesOrderLines.tenantId, tenantId),
+      ));
+
+    if (lines.length === 0) {
+      throw Object.assign(new Error('Sales order has no lines'), { statusCode: 409 });
+    }
+
+    // Transition to processing
+    const [updated] = await tx
+      .update(salesOrders)
+      .set({ status: 'processing', updatedAt: new Date() })
+      .where(eq(salesOrders.id, orderId))
+      .returning();
+
+    // Reserve inventory per line
+    const reservations: LineReservationResult[] = [];
+
+    for (const line of lines) {
+      // Ensure inventory ledger row exists
+      await upsertInventoryInTx(tx, tenantId, order.facilityId, line.partId);
+
+      // Check available inventory
+      const [ledgerRow] = await tx
+        .select()
+        .from(inventoryLedger)
+        .where(and(
+          eq(inventoryLedger.tenantId, tenantId),
+          eq(inventoryLedger.facilityId, order.facilityId),
+          eq(inventoryLedger.partId, line.partId),
+        ))
+        .for('update');
+
+      const available = ledgerRow ? (ledgerRow.qtyOnHand - ledgerRow.qtyReserved) : 0;
+      const needed = line.quantityOrdered - line.quantityAllocated;
+      const reservable = Math.min(Math.max(0, available), needed);
+
+      if (reservable > 0) {
+        // Increment qtyReserved on the ledger
+        await tx
+          .update(inventoryLedger)
+          .set({
+            qtyReserved: sql`${inventoryLedger.qtyReserved} + ${reservable}`,
+            updatedAt: new Date(),
+          })
+          .where(eq(inventoryLedger.id, ledgerRow!.id));
+
+        // Update quantityAllocated on the line
+        await tx
+          .update(salesOrderLines)
+          .set({
+            quantityAllocated: line.quantityAllocated + reservable,
+            updatedAt: new Date(),
+          })
+          .where(eq(salesOrderLines.id, line.id));
+      }
+
+      reservations.push({
+        lineId: line.id,
+        partId: line.partId,
+        quantityOrdered: line.quantityOrdered,
+        quantityReserved: reservable,
+        shortfall: needed - reservable,
+      });
+
+      // Record demand signal (append-only)
+      await tx.insert(demandSignals).values({
+        tenantId,
+        partId: line.partId,
+        facilityId: order.facilityId,
+        signalType: 'sales_order',
+        quantityDemanded: line.quantityOrdered,
+        quantityFulfilled: reservable,
+        salesOrderId: orderId,
+        salesOrderLineId: line.id,
+        demandDate: new Date(),
+        metadata: {
+          soNumber: order.soNumber,
+          lineNumber: line.lineNumber,
+          unitPrice: line.unitPrice,
+        },
+      });
+    }
+
+    // Write audit entry
+    await writeAuditEntry(tx, {
+      tenantId,
+      userId: auditContext.userId,
+      action: 'sales_order.approved',
+      entityType: 'sales_order',
+      entityId: orderId,
+      previousState: { status: 'confirmed' },
+      newState: {
+        status: 'processing',
+        reservations: reservations.map((r) => ({
+          partId: r.partId,
+          reserved: r.quantityReserved,
+          shortfall: r.shortfall,
+        })),
+      },
+      metadata: {
+        source: 'sales-order-approval.approve',
+        soNumber: order.soNumber,
+        lineCount: lines.length,
+        totalReserved: reservations.reduce((sum, r) => sum + r.quantityReserved, 0),
+        totalShortfall: reservations.reduce((sum, r) => sum + r.shortfall, 0),
+      },
+      ipAddress: auditContext.ipAddress,
+      userAgent: auditContext.userAgent,
+    });
+
+    // Record stockout_inquiry signals for shortfall lines
+    for (const r of reservations) {
+      if (r.shortfall > 0) {
+        await tx.insert(demandSignals).values({
+          tenantId,
+          partId: r.partId,
+          facilityId: order.facilityId,
+          signalType: 'reorder_point',
+          quantityDemanded: r.shortfall,
+          quantityFulfilled: 0,
+          salesOrderId: orderId,
+          salesOrderLineId: r.lineId,
+          demandDate: new Date(),
+          metadata: {
+            type: 'stockout_inquiry',
+            soNumber: order.soNumber,
+            reason: 'insufficient_inventory',
+          },
+        });
+      }
+    }
+
+    return {
+      order: updated,
+      reservations,
+      demandSignalsCreated: lines.length + reservations.filter((r) => r.shortfall > 0).length,
+    };
+  });
+
+  // Phase 2: Kanban trigger evaluation (outside main transaction for isolation)
+  let kanbanCardsTriggered = 0;
+  const uniqueParts = [...new Set(txResult.reservations.map((r) => r.partId))];
+
+  for (const partId of uniqueParts) {
+    try {
+      const triggered = await evaluateKanbanTrigger(tenantId, facilityId, partId);
+      if (triggered) kanbanCardsTriggered++;
+    } catch (err) {
+      log.warn({ err, partId, facilityId }, 'Kanban trigger evaluation failed — non-blocking');
+    }
+  }
+
+  // Phase 3: Publish events (non-blocking — failures don't affect the approval)
+  try {
+    const eventBus = getEventBus();
+    const now = new Date().toISOString();
+
+    const statusEvent: OrderStatusChangedEvent = {
+      type: 'order.status_changed',
+      tenantId,
+      orderType: 'sales_order',
+      orderId,
+      orderNumber: txResult.order.soNumber,
+      fromStatus: 'confirmed',
+      toStatus: 'processing',
+      timestamp: now,
+    };
+    await eventBus.publish(statusEvent, buildEventMeta());
+
+    const approvedEvent: SalesOrderApprovedEvent = {
+      type: 'sales_order.approved',
+      tenantId,
+      orderId,
+      orderNumber: txResult.order.soNumber,
+      customerId: txResult.order.customerId,
+      facilityId: txResult.order.facilityId,
+      lineCount: txResult.reservations.length,
+      totalAmount: txResult.order.totalAmount ?? '0',
+      reservationSummary: {
+        totalRequested: txResult.reservations.reduce((s, r) => s + r.quantityOrdered, 0),
+        totalReserved: txResult.reservations.reduce((s, r) => s + r.quantityReserved, 0),
+        shortfallLines: txResult.reservations.filter((r) => r.shortfall > 0).length,
+      },
+      timestamp: now,
+    };
+    await eventBus.publish(approvedEvent, buildEventMeta());
+  } catch (err) {
+    log.warn({ err, orderId }, 'Failed to publish approval events — non-blocking');
+  }
+
+  return {
+    orderId,
+    orderNumber: txResult.order.soNumber,
+    previousStatus: 'confirmed',
+    newStatus: 'processing',
+    reservations: txResult.reservations,
+    demandSignalsCreated: txResult.demandSignalsCreated,
+    kanbanCardsTriggered,
+  };
+}
+
+// ─── Cancel Sales Order ───────────────────────────────────────────────
+
+/**
+ * Cancel a sales order and release reserved inventory:
+ * 1. Transition to cancelled
+ * 2. Release inventory reservations (decrement qtyReserved)
+ * 3. Record cancellation demand signals
+ */
+export async function cancelSalesOrder(
+  orderId: string,
+  tenantId: string,
+  userId: string,
+  cancelReason: string | undefined,
+  auditContext: AuditContext,
+): Promise<CancellationResult> {
+  const txResult = await db.transaction(async (tx) => {
+    const [order] = await tx
+      .select()
+      .from(salesOrders)
+      .where(and(eq(salesOrders.id, orderId), eq(salesOrders.tenantId, tenantId)))
+      .for('update');
+
+    if (!order) {
+      throw Object.assign(new Error('Sales order not found'), { statusCode: 404 });
+    }
+
+    const terminalStatuses = ['cancelled', 'closed'];
+    if (terminalStatuses.includes(order.status)) {
+      throw Object.assign(
+        new Error(`Cannot cancel order in "${order.status}" status`),
+        { statusCode: 409 },
+      );
+    }
+
+    const previousStatus = order.status;
+
+    // Transition to cancelled
+    await tx
+      .update(salesOrders)
+      .set({
+        status: 'cancelled',
+        cancelledAt: new Date(),
+        cancelReason: cancelReason ?? null,
+        updatedAt: new Date(),
+      })
+      .where(eq(salesOrders.id, orderId));
+
+    // Release reserved inventory for lines with allocations
+    const lines = await tx
+      .select()
+      .from(salesOrderLines)
+      .where(and(
+        eq(salesOrderLines.salesOrderId, orderId),
+        eq(salesOrderLines.tenantId, tenantId),
+      ));
+
+    let totalReleased = 0;
+
+    for (const line of lines) {
+      if (line.quantityAllocated > 0) {
+        // Decrement qtyReserved on inventory ledger
+        const [ledgerRow] = await tx
+          .select()
+          .from(inventoryLedger)
+          .where(and(
+            eq(inventoryLedger.tenantId, tenantId),
+            eq(inventoryLedger.facilityId, order.facilityId),
+            eq(inventoryLedger.partId, line.partId),
+          ))
+          .for('update');
+
+        if (ledgerRow) {
+          const releaseQty = Math.min(line.quantityAllocated, ledgerRow.qtyReserved);
+          if (releaseQty > 0) {
+            await tx
+              .update(inventoryLedger)
+              .set({
+                qtyReserved: sql`${inventoryLedger.qtyReserved} - ${releaseQty}`,
+                updatedAt: new Date(),
+              })
+              .where(eq(inventoryLedger.id, ledgerRow.id));
+            totalReleased += releaseQty;
+          }
+        }
+
+        // Reset allocation on line
+        await tx
+          .update(salesOrderLines)
+          .set({ quantityAllocated: 0, updatedAt: new Date() })
+          .where(eq(salesOrderLines.id, line.id));
+      }
+    }
+
+    // Record cancellation demand signals (reversal entries)
+    let demandSignalsCancelled = 0;
+    for (const line of lines) {
+      if (line.quantityOrdered > 0) {
+        await tx.insert(demandSignals).values({
+          tenantId,
+          partId: line.partId,
+          facilityId: order.facilityId,
+          signalType: 'sales_order',
+          quantityDemanded: -line.quantityOrdered,
+          quantityFulfilled: 0,
+          salesOrderId: orderId,
+          salesOrderLineId: line.id,
+          demandDate: new Date(),
+          metadata: {
+            type: 'cancellation',
+            soNumber: order.soNumber,
+            lineNumber: line.lineNumber,
+            previousStatus,
+            cancelReason: cancelReason ?? null,
+          },
+        });
+        demandSignalsCancelled++;
+      }
+    }
+
+    // Audit entry
+    await writeAuditEntry(tx, {
+      tenantId,
+      userId: auditContext.userId,
+      action: 'sales_order.cancelled',
+      entityType: 'sales_order',
+      entityId: orderId,
+      previousState: { status: previousStatus },
+      newState: { status: 'cancelled', cancelReason },
+      metadata: {
+        source: 'sales-order-approval.cancel',
+        soNumber: order.soNumber,
+        inventoryReleased: totalReleased,
+        demandSignalsCancelled,
+      },
+      ipAddress: auditContext.ipAddress,
+      userAgent: auditContext.userAgent,
+    });
+
+    return {
+      orderNumber: order.soNumber,
+      previousStatus,
+      totalReleased,
+      demandSignalsCancelled,
+    };
+  });
+
+  // Publish events outside transaction
+  try {
+    const eventBus = getEventBus();
+    const now = new Date().toISOString();
+
+    const statusEvent: OrderStatusChangedEvent = {
+      type: 'order.status_changed',
+      tenantId,
+      orderType: 'sales_order',
+      orderId,
+      orderNumber: txResult.orderNumber,
+      fromStatus: txResult.previousStatus,
+      toStatus: 'cancelled',
+      timestamp: now,
+    };
+    await eventBus.publish(statusEvent, buildEventMeta());
+
+    const cancelledEvent: SalesOrderCancelledEvent = {
+      type: 'sales_order.cancelled',
+      tenantId,
+      orderId,
+      orderNumber: txResult.orderNumber,
+      previousStatus: txResult.previousStatus,
+      cancelReason,
+      inventoryReleased: txResult.totalReleased,
+      demandSignalsCancelled: txResult.demandSignalsCancelled,
+      timestamp: now,
+    };
+    await eventBus.publish(cancelledEvent, buildEventMeta());
+  } catch (err) {
+    log.warn({ err, orderId }, 'Failed to publish cancellation events — non-blocking');
+  }
+
+  return {
+    orderId,
+    orderNumber: txResult.orderNumber,
+    previousStatus: txResult.previousStatus,
+    inventoryReleased: txResult.totalReleased,
+    demandSignalsCancelled: txResult.demandSignalsCancelled,
+  };
+}
+
+// ─── Kanban Trigger Evaluation ────────────────────────────────────────
+
+/**
+ * Evaluate whether a kanban card should be triggered for a given part at a facility.
+ * Conditions:
+ *   1. An active kanban loop exists for (facility, part)
+ *   2. Available inventory (qtyOnHand - qtyReserved) <= minQuantity (reorder point)
+ *   3. No existing triggered or ordered cards in the loop
+ *
+ * Returns true if a card was triggered.
+ */
+async function evaluateKanbanTrigger(
+  tenantId: string,
+  facilityId: string,
+  partId: string,
+): Promise<boolean> {
+  // Find active kanban loops for this part+facility
+  const loops = await db
+    .select()
+    .from(kanbanLoops)
+    .where(and(
+      eq(kanbanLoops.tenantId, tenantId),
+      eq(kanbanLoops.facilityId, facilityId),
+      eq(kanbanLoops.partId, partId),
+      eq(kanbanLoops.isActive, true),
+    ));
+
+  if (loops.length === 0) return false;
+
+  // Check inventory level
+  const [ledgerRow] = await db
+    .select()
+    .from(inventoryLedger)
+    .where(and(
+      eq(inventoryLedger.tenantId, tenantId),
+      eq(inventoryLedger.facilityId, facilityId),
+      eq(inventoryLedger.partId, partId),
+    ));
+
+  if (!ledgerRow) return false;
+
+  const available = ledgerRow.qtyOnHand - ledgerRow.qtyReserved;
+
+  let triggered = false;
+
+  for (const loop of loops) {
+    // Check if available <= reorder point
+    if (available > loop.minQuantity) continue;
+
+    // Check if there are already active (triggered/ordered) cards
+    const activeCards = await db
+      .select({ id: kanbanCards.id })
+      .from(kanbanCards)
+      .where(and(
+        eq(kanbanCards.loopId, loop.id),
+        eq(kanbanCards.tenantId, tenantId),
+        eq(kanbanCards.isActive, true),
+        inArray(kanbanCards.currentStage, ['triggered', 'ordered']),
+      ))
+      .limit(1);
+
+    if (activeCards.length > 0) continue;
+
+    // Find a restocked or created card to trigger
+    const [eligibleCard] = await db
+      .select()
+      .from(kanbanCards)
+      .where(and(
+        eq(kanbanCards.loopId, loop.id),
+        eq(kanbanCards.tenantId, tenantId),
+        eq(kanbanCards.isActive, true),
+        inArray(kanbanCards.currentStage, ['restocked', 'created']),
+      ))
+      .limit(1);
+
+    if (!eligibleCard) continue;
+
+    // Trigger the card
+    await db
+      .update(kanbanCards)
+      .set({
+        currentStage: 'triggered',
+        currentStageEnteredAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(kanbanCards.id, eligibleCard.id));
+
+    log.info({
+      loopId: loop.id,
+      cardId: eligibleCard.id,
+      partId,
+      facilityId,
+      available,
+      minQuantity: loop.minQuantity,
+    }, 'Kanban card triggered by sales order approval');
+
+    triggered = true;
+  }
+
+  return triggered;
+}
+
+// ─── Upsert inventory in transaction context ─────────────────────────
+
+async function upsertInventoryInTx(
+  tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+  tenantId: string,
+  facilityId: string,
+  partId: string,
+): Promise<void> {
+  await tx
+    .insert(inventoryLedger)
+    .values({
+      tenantId,
+      facilityId,
+      partId,
+      qtyOnHand: 0,
+      qtyReserved: 0,
+      qtyInTransit: 0,
+      reorderPoint: 0,
+      reorderQty: 0,
+    })
+    .onConflictDoNothing({
+      target: [inventoryLedger.tenantId, inventoryLedger.facilityId, inventoryLedger.partId],
+    });
+}


### PR DESCRIPTION
## Changes

Wire sales order approval flow with inventory reservation, demand signal recording, Kanban trigger evaluation, and cancellation release:

- **Approval service** (`sales-order-approval.service.ts`): `approveSalesOrder()` transitions confirmed → processing, reserves inventory per line, records demand signals, evaluates kanban triggers. `cancelSalesOrder()` releases reserved inventory and records reversal demand signals.
- **Event types**: `SalesOrderApprovedEvent`, `SalesOrderCancelledEvent`, `DemandSignalCreatedEvent` in `@arda/events`. Extended `OrderStatusChangedEvent` to support `sales_order` orderType.
- **WebSocket events**: Added `so:status_changed` and `demand_signal:created` to `WS_EVENT_TYPES`. Updated gateway event mapper.
- **Routes**: `POST /sales-orders/:id/approve` (ecommerce_director + tenant_admin), `POST /sales-orders/:id/cancel-with-release` (salesperson + tenant_admin)

### Key Implementation Details

1. **Inventory reservation** runs inside the approval transaction — locks ledger rows FOR UPDATE, increments qtyReserved, updates line quantityAllocated
2. **Partial reservation** handled gracefully — reserves what's available, records shortfall via `reorder_point` demand signals with `stockout_inquiry` metadata
3. **Kanban trigger evaluation** runs outside the main transaction for isolation — checks if available <= minQuantity and no active triggered/ordered cards exist
4. **Cancellation** releases only up to the available reserved quantity (defensive against drift) and records negative-quantity reversal demand signals
5. **Events published outside transactions** — failures don't rollback DB changes (non-blocking pattern)

## Acceptance Criteria

- [x] On order approval, system transitions confirmed → processing and reserves inventory per line
- [x] Partial/insufficient inventory sets quantity_reserved correctly and records stockout_inquiry signals
- [x] Kanban trigger evaluation runs for affected (facility_id, part_id) and triggers eligible cards
- [x] Order cancellation releases reserved inventory and records cancellation demand events
- [x] sales_order.approved, sales_order.cancelled, and demand_signal events wired per event architecture

## Testing

- 20 unit tests (approval: full reserve, partial, zero, multi-line, reject non-confirmed, reject no lines, audit, demand signals, stockout signals, existing allocations | cancellation: release, no allocations, terminal status, closed, audit, reversals, multi-line, release cap, not found)
- 10 integration tests (approve: RBAC for ecommerce_director/tenant_admin/salesperson/inventory_manager, not found, service errors | cancel-with-release: RBAC for salesperson/tenant_admin/executive, service errors)
- 849 total orders service tests passing, typecheck clean

Closes #194